### PR TITLE
add in freshness policies

### DIFF
--- a/hooli_data_eng/assets/marketing/__init__.py
+++ b/hooli_data_eng/assets/marketing/__init__.py
@@ -1,0 +1,23 @@
+from dagster import asset, FreshnessPolicy
+import pandas as pd
+
+@asset(
+    key_prefix="MARKETING", 
+    freshness_policy=FreshnessPolicy(maximum_lag_minutes=90), 
+    compute_kind="pandas"
+)
+def avg_order(company_perf: pd.DataFrame) -> pd.DataFrame:
+    return pd.DataFrame({
+        "avg_order": company_perf['total_revenue'] / company_perf['n_orders'] 
+    })
+
+
+@asset(
+    key_prefix="MARKETING", 
+    freshness_policy=FreshnessPolicy(maximum_lag_minutes=90), 
+    compute_kind="pandas"
+)
+def max_order(company_perf: pd.DataFrame) -> pd.DataFrame:
+    return pd.DataFrame({
+        "max_order": max(company_perf['n_orders'])
+    })


### PR DESCRIPTION
- adds two new assets under marketing with freshness policies
- one asset is tracked by a reconciliation sensor to show how its policy will trigger runs (the policy requires data less fresh than the schedule on the orders_augmented dataset, so the freshness policy should only update the intermediate marketing assets)
- the other asset has a freshness policy but is not tracked by a reconciliation sensor, showing how policies can cause a late status