### PR TITLE
Add partitions

### DIFF
--- a/dbt_project/models/ANALYTICS/daily_order_summary.sql
+++ b/dbt_project/models/ANALYTICS/daily_order_summary.sql
@@ -9,3 +9,6 @@ select
         order_date,
         n_orders as num_orders
 from {{ ref("order_stats") }}
+{% if is_incremental() %}
+WHERE o.order_date = '{{ var('datetime_to_process') }}'
+{% endif %}

--- a/dbt_project/models/ANALYTICS/orders_augmented.sql
+++ b/dbt_project/models/ANALYTICS/orders_augmented.sql
@@ -4,3 +4,6 @@ select
 from
         {{ ref("orders_cleaned") }} o left join
         {{ ref("users_cleaned") }} u on (o.user_id = u.user_id)
+{% if is_incremental() %}
+WHERE o.order_date = '{{ var('datetime_to_process') }}'
+{% endif %}

--- a/dbt_project/models/CLEANED/orders_cleaned.sql
+++ b/dbt_project/models/CLEANED/orders_cleaned.sql
@@ -7,3 +7,6 @@ select
         cast(dt as datetime) as order_date,
         quantity * purchase_price as order_total
 from {{ source("RAW_DATA", "orders") }}
+{% if is_incremental() %}
+WHERE dt = '{{ var('datetime_to_process') }}'
+{% endif %}

--- a/hooli_data_eng/assets/dbt_assets.py
+++ b/hooli_data_eng/assets/dbt_assets.py
@@ -17,6 +17,7 @@ def dbt_metadata(context, node_info):
     return {
         "owner": "data@hooli.com",
         "name": node_info["name"],
+        "partition_expr": "dt"
     }
 
 def partition_key_to_vars(partition_key):
@@ -26,17 +27,28 @@ hourly_dbt_assets = load_assets_from_dbt_project(
     DBT_PROJECT_DIR,
     DBT_PROFILES_DIR,
     key_prefix=["ANALYTICS"],
+    source_key_prefix="ANALYTICS",
     runtime_metadata_fn=dbt_metadata,
     partition_key_to_vars_fn=partition_key_to_vars,
     partitions_def=hourly_partitions,
-    select="+orders_augmented", 
-    exclude="users_cleaned"
+    select="orders_augmented"
+)
+
+hourly_dbt_assets_orders = load_assets_from_dbt_project(
+    DBT_PROJECT_DIR,
+    DBT_PROFILES_DIR,
+    key_prefix=["ANALYTICS"],
+    runtime_metadata_fn=dbt_metadata,
+    partition_key_to_vars_fn=partition_key_to_vars,
+    partitions_def=hourly_partitions,
+    select="orders_cleaned"
 )
 
 daily_dbt_assets = load_assets_from_dbt_project(
     DBT_PROJECT_DIR,
     DBT_PROFILES_DIR,
     key_prefix=["ANALYTICS"],
+    source_key_prefix="ANALYTICS",
     runtime_metadata_fn=dbt_metadata,
     partition_key_to_vars_fn=partition_key_to_vars,
     partitions_def=daily_partitions,
@@ -47,6 +59,16 @@ dbt_views = load_assets_from_dbt_project(
     DBT_PROJECT_DIR,
     DBT_PROFILES_DIR,
     key_prefix=["ANALYTICS"],
+    source_key_prefix="ANALYTICS",
     runtime_metadata_fn=dbt_metadata,
-    select="company_perf sku_stats company_stats users_cleaned"
+    select="company_perf sku_stats company_stats"
 )
+
+dbt_views_users = load_assets_from_dbt_project(
+    DBT_PROJECT_DIR,
+    DBT_PROFILES_DIR,
+    key_prefix=["ANALYTICS"],
+    runtime_metadata_fn=dbt_metadata,
+    select="users_cleaned"
+)
+

--- a/hooli_data_eng/assets/dbt_assets.py
+++ b/hooli_data_eng/assets/dbt_assets.py
@@ -1,0 +1,52 @@
+
+from dagster._utils import file_relative_path
+from dagster_dbt import load_assets_from_dbt_project
+from dagster import DailyPartitionsDefinition, HourlyPartitionsDefinition
+
+daily_partitions = DailyPartitionsDefinition(start_date="2023-04-01")
+
+hourly_partitions = HourlyPartitionsDefinition(
+    start_date="2023-04-01-00:00"
+)
+
+DBT_PROJECT_DIR = file_relative_path(__file__, "../../dbt_project")
+DBT_PROFILES_DIR = file_relative_path(__file__, "../../dbt_project/config")
+
+
+def dbt_metadata(context, node_info):
+    return {
+        "owner": "data@hooli.com",
+        "name": node_info["name"],
+    }
+
+def partition_key_to_vars(partition_key):
+    return {"datetime_to_process": partition_key}
+
+hourly_dbt_assets = load_assets_from_dbt_project(
+    DBT_PROJECT_DIR,
+    DBT_PROFILES_DIR,
+    key_prefix=["ANALYTICS"],
+    runtime_metadata_fn=dbt_metadata,
+    partition_key_to_vars_fn=partition_key_to_vars,
+    partitions_def=hourly_partitions,
+    select="+order_stats", 
+    exclude="users_cleaned"
+)
+
+daily_dbt_assets = load_assets_from_dbt_project(
+    DBT_PROJECT_DIR,
+    DBT_PROFILES_DIR,
+    key_prefix=["ANALYTICS"],
+    runtime_metadata_fn=dbt_metadata,
+    partition_key_to_vars_fn=partition_key_to_vars,
+    partitions_def=daily_partitions,
+    select="daily_order_summary"
+)
+
+dbt_views = load_assets_from_dbt_project(
+    DBT_PROJECT_DIR,
+    DBT_PROFILES_DIR,
+    key_prefix=["ANALYTICS"],
+    runtime_metadata_fn=dbt_metadata,
+    select="company_perf sku_stats company_stats users_cleaned"
+)

--- a/hooli_data_eng/assets/dbt_assets.py
+++ b/hooli_data_eng/assets/dbt_assets.py
@@ -29,7 +29,7 @@ hourly_dbt_assets = load_assets_from_dbt_project(
     runtime_metadata_fn=dbt_metadata,
     partition_key_to_vars_fn=partition_key_to_vars,
     partitions_def=hourly_partitions,
-    select="+order_stats", 
+    select="+orders_augmented", 
     exclude="users_cleaned"
 )
 
@@ -40,7 +40,7 @@ daily_dbt_assets = load_assets_from_dbt_project(
     runtime_metadata_fn=dbt_metadata,
     partition_key_to_vars_fn=partition_key_to_vars,
     partitions_def=daily_partitions,
-    select="daily_order_summary"
+    select="daily_order_summary order_stats"
 )
 
 dbt_views = load_assets_from_dbt_project(

--- a/hooli_data_eng/assets/dbt_assets.py
+++ b/hooli_data_eng/assets/dbt_assets.py
@@ -3,27 +3,50 @@ from dagster._utils import file_relative_path
 from dagster_dbt import load_assets_from_dbt_project
 from dagster import DailyPartitionsDefinition, HourlyPartitionsDefinition
 
-daily_partitions = DailyPartitionsDefinition(start_date="2023-04-01")
-
-hourly_partitions = HourlyPartitionsDefinition(
-    start_date="2023-04-01-00:00"
-)
-
 DBT_PROJECT_DIR = file_relative_path(__file__, "../../dbt_project")
 DBT_PROFILES_DIR = file_relative_path(__file__, "../../dbt_project/config")
 
-
+# dbt assets contain some default metadata
+# for example dagster will show the schema definitions from
+# the dbt project on the asset definition page 
+# this function adds extra metadata to each asset materialization
 def dbt_metadata(context, node_info):
     return {
         "owner": "data@hooli.com",
-        "name": node_info["name"],
-        "partition_expr": "dt"
+        "name": node_info["name"]
     }
 
+# many dbt assets use an incremental approach to avoid
+# re-processing all data on each run
+# this approach can be modelled in dagster using partitions 
+# this project includes assets with hourly and daily partitions
+hourly_partitions = HourlyPartitionsDefinition(start_date="2023-04-01-00:00")
+daily_partitions = DailyPartitionsDefinition(start_date="2023-04-01")
+
 def partition_key_to_vars(partition_key):
+    """ Map dagster partitions to the dbt var used in our model WHERE clauses """
     return {"datetime_to_process": partition_key}
 
-hourly_dbt_assets = load_assets_from_dbt_project(
+def io_partition_metadata_fn_dt(_):
+    """ Tells dagster how to load partitioned dbt assets by mapping a partition to dt column """
+    return {"partition_expr": "dt"}
+
+def io_partition_metadata_fn_order_date(_):
+    """ Tells dagster how to load partitioned dbt assets by mapping a partition to a column """
+    return {"partition_expr": "order_date"}
+
+orders_cleaned_hourly = load_assets_from_dbt_project(
+    DBT_PROJECT_DIR,
+    DBT_PROFILES_DIR,
+    key_prefix=["ANALYTICS"],
+    runtime_metadata_fn=dbt_metadata,
+    partition_key_to_vars_fn=partition_key_to_vars,
+    partitions_def=hourly_partitions,
+    node_info_to_definition_metadata_fn=io_partition_metadata_fn_dt,
+    select="orders_cleaned"
+)
+
+orders_augmented_hourly = load_assets_from_dbt_project(
     DBT_PROJECT_DIR,
     DBT_PROFILES_DIR,
     key_prefix=["ANALYTICS"],
@@ -31,17 +54,16 @@ hourly_dbt_assets = load_assets_from_dbt_project(
     runtime_metadata_fn=dbt_metadata,
     partition_key_to_vars_fn=partition_key_to_vars,
     partitions_def=hourly_partitions,
+    node_info_to_definition_metadata_fn=io_partition_metadata_fn_order_date,
     select="orders_augmented"
 )
 
-hourly_dbt_assets_orders = load_assets_from_dbt_project(
+users_cleaned = load_assets_from_dbt_project(
     DBT_PROJECT_DIR,
     DBT_PROFILES_DIR,
     key_prefix=["ANALYTICS"],
     runtime_metadata_fn=dbt_metadata,
-    partition_key_to_vars_fn=partition_key_to_vars,
-    partitions_def=hourly_partitions,
-    select="orders_cleaned"
+    select="users_cleaned"
 )
 
 daily_dbt_assets = load_assets_from_dbt_project(
@@ -52,6 +74,7 @@ daily_dbt_assets = load_assets_from_dbt_project(
     runtime_metadata_fn=dbt_metadata,
     partition_key_to_vars_fn=partition_key_to_vars,
     partitions_def=daily_partitions,
+    node_info_to_definition_metadata_fn=io_partition_metadata_fn_order_date,
     select="daily_order_summary order_stats"
 )
 
@@ -64,11 +87,5 @@ dbt_views = load_assets_from_dbt_project(
     select="company_perf sku_stats company_stats"
 )
 
-dbt_views_users = load_assets_from_dbt_project(
-    DBT_PROJECT_DIR,
-    DBT_PROFILES_DIR,
-    key_prefix=["ANALYTICS"],
-    runtime_metadata_fn=dbt_metadata,
-    select="users_cleaned"
-)
+
 

--- a/hooli_data_eng/assets/forecasting/__init__.py
+++ b/hooli_data_eng/assets/forecasting/__init__.py
@@ -28,14 +28,11 @@ def model_func(x, a, b):
 # using context.log.info
 @asset(
     ins={"daily_order_summary": AssetIn(key_prefix=["ANALYTICS"])},
-    compute_kind="ml_tool",
+    compute_kind="scikitlearn",
     io_manager_key="model_io_manager",
     config_schema={"a_init": Field(Int, default_value=5), "b_init": Field(Int, default_value=5)}
-    
 )
 def order_forecast_model(context, daily_order_summary: pd.DataFrame) -> Any:
-
-
     """Model parameters that best fit the observed data"""
     df = daily_order_summary
     p0 = [context.op_config["a_init"], context.op_config["b_init"]]
@@ -58,7 +55,7 @@ def order_forecast_model(context, daily_order_summary: pd.DataFrame) -> Any:
         "daily_order_summary": AssetIn(key_prefix=["ANALYTICS"]),
         "order_forecast_model": AssetIn(),
     },
-    compute_kind="ml_tool",
+    compute_kind="scikitlearn",
     key_prefix=["forecasting"],
     io_manager_key="model_io_manager",
     partitions_def=MonthlyPartitionsDefinition(start_date="2022-01-01")
@@ -88,7 +85,7 @@ def model_stats_by_month(context, daily_order_summary: pd.DataFrame, order_forec
         "daily_order_summary": AssetIn(key_prefix=["ANALYTICS"]),
         "order_forecast_model": AssetIn(),
     },
-    compute_kind="ml_tool",
+    compute_kind="pandas",
     key_prefix=["FORECASTING"],
 )
 def predicted_orders(

--- a/hooli_data_eng/definitions.py
+++ b/hooli_data_eng/definitions.py
@@ -195,7 +195,7 @@ resource_def = {
 # upstream of daily_order_summary.
 analytics_job = define_asset_job(
      name = "refresh_analytics_model_job",
-     selection=AssetSelection.keys(["ANALYTICS", "order_stats"]).upstream(), 
+     selection=AssetSelection.keys(["ANALYTICS", "orders_augmented"]).upstream(), 
      tags = {"dagster/max_retries": "1"},
      # config = {"execution": {"config": {"multiprocess": {"max_concurrent": 1}}}}
 )

--- a/hooli_data_eng/resources/api.py
+++ b/hooli_data_eng/resources/api.py
@@ -22,7 +22,7 @@ class RawDataAPI():
     @responses.activate
     def get_orders(_, datetime_to_process):
         # add lots of flakiness
-        if random.randint(0,10) <= -1:
+        if random.randint(0,10) <= 4:
             raise Exception("API time out")
 
         responses.get(
@@ -32,7 +32,8 @@ class RawDataAPI():
             # random order data returned, see utils.py
             json = random_data(
                extra_columns={"order_id": str, "quantity": int, "purchase_price": float, "sku": str},
-               n = 1000
+               n = 10,
+               filter_date=datetime_to_process
             ).to_json()
         )
 
@@ -41,7 +42,7 @@ class RawDataAPI():
     @responses.activate
     def get_users(_):
         # add some of flakiness
-        if random.randint(0,10) <= -1:
+        if random.randint(0,10) <= 2:
             raise Exception("API time out")
 
         responses.get(

--- a/hooli_data_eng/resources/api.py
+++ b/hooli_data_eng/resources/api.py
@@ -20,9 +20,9 @@ class RawDataAPI():
         pass
 
     @responses.activate
-    def get_orders(_):
+    def get_orders(_, datetime_to_process):
         # add lots of flakiness
-        if random.randint(0,10) <= 6:
+        if random.randint(0,10) <= -1:
             raise Exception("API time out")
 
         responses.get(
@@ -41,7 +41,7 @@ class RawDataAPI():
     @responses.activate
     def get_users(_):
         # add some of flakiness
-        if random.randint(0,10) <= 3:
+        if random.randint(0,10) <= -1:
             raise Exception("API time out")
 
         responses.get(

--- a/hooli_data_eng/utils/__init__.py
+++ b/hooli_data_eng/utils/__init__.py
@@ -2,7 +2,7 @@ import datetime
 import time
 import uuid
 from typing import Any, Dict, List
-
+import random
 import numpy as np
 import pandas as pd
 
@@ -25,18 +25,36 @@ def _random_times(n: int):
         clipped_flipped_dist = np.append(
             clipped_flipped_dist, clipped_flipped_dist[: n - len(clipped_flipped_dist)]
         )
+    
+    times = pd.to_datetime((clipped_flipped_dist * (end_u - start_u)) + start_u, unit="s")
 
-    return pd.to_datetime((clipped_flipped_dist * (end_u - start_u)) + start_u, unit="s")
+    hours = times.round('60min').to_pydatetime()
+
+    return hours
 
 
-def random_data(extra_columns: Dict[str, Any], n: int) -> pd.DataFrame:
-    # always have user_id and day
-    data = {"user_id": np.random.randint(0, 1000, size=n), "dt": _random_times(n)}
+def random_data(extra_columns: Dict[str, Any], n: int, filter_date = None) -> pd.DataFrame:
+    
+    skus = ["pepsi", "coke", "sprite", "coke zero", "powerade", "diet", "gingerale", "juice"]
+    
+    # always have user_id 
+    data = {"user_id": np.random.randint(0, 1000, size=n)}
+
     for name, dtype in extra_columns.items():
-        if dtype == str:
+        if name == "sku": 
+            data[name] = random.choices(skus, k=n)
+        elif dtype == str:
             data[name] = [str(uuid.uuid4()) for _ in range(n)]
         elif dtype == int:
             data[name] = np.random.randint(0, 100, size=n)
         elif dtype == float:
             data[name] = 100 * np.random.random(size=n)
+    
+    data = pd.DataFrame(data)
+
+    if filter_date:
+        data["dt"] = pd.to_datetime(filter_date)
+    else:
+        data["dt"] = _random_times(n=n)
+
     return pd.DataFrame(data)


### PR DESCRIPTION
Adds hourly and daily partitions to the relevant EL assets and dbt assets. Also adds an example of a dynamic partition.

Of note:
- updates the dbt models to include incremental updates, includes an example of daily partitions rolling into hourly partitions
- adds a mapping between dagster partitions, dbt vars, and partition_expr metadata
- adds a dynamic partition to pull reports by product sku
- refactors the random data to present meaningful skus and partition-correct date times 