### PR TITLE
allow for single run backfills

### DIFF
--- a/hooli_data_eng/assets/dbt_assets.py
+++ b/hooli_data_eng/assets/dbt_assets.py
@@ -20,8 +20,8 @@ def dbt_metadata(context, node_info):
 # re-processing all data on each run
 # this approach can be modelled in dagster using partitions 
 # this project includes assets with hourly and daily partitions
-hourly_partitions = HourlyPartitionsDefinition(start_date="2023-04-10-17:00")
-daily_partitions = DailyPartitionsDefinition(start_date="2023-04-10")
+hourly_partitions = HourlyPartitionsDefinition(start_date="2023-04-11-00:00")
+daily_partitions = DailyPartitionsDefinition(start_date="2023-04-12")
 
 def partition_key_to_vars(partition_key):
     """ Map dagster partitions to the dbt var used in our model WHERE clauses """

--- a/hooli_data_eng_tests/test_assets.py
+++ b/hooli_data_eng_tests/test_assets.py
@@ -1,1 +1,74 @@
 
+from hooli_data_eng.assets.raw_data import orders, users, hourly_partitions, build_op_context
+from hooli_data_eng.resources.api import data_api
+
+from dagster import define_asset_job, Definitions
+
+from dagster_duckdb_pandas import DuckDBPandasIOManager
+import duckdb
+import os
+
+def test_orders_single_partition():
+    orders_df = orders(
+        build_op_context(
+            resources={"data_api": data_api.configured({"flaky": False})},
+            partition_key="2023-04-10-22:00"
+        )
+    )
+    assert len(orders_df) == 10
+
+def test_users_single_partition():
+    users_df = users(
+        build_op_context(
+            resources={"data_api": data_api.configured({"flaky": False})},
+            partition_key="2023-04-10-22:00"
+        )
+    )
+    assert len(users_df) == 10
+
+def test_orders_multi_partition_backfill():
+    test_job = define_asset_job("test_job", selection=["orders"])
+    test_resources = {"io_manager": DuckDBPandasIOManager(database="test.duckdb"), "data_api": data_api.configured({"flaky": False})}
+    defs = Definitions(
+        assets=[orders], 
+        jobs=[test_job],
+        resources = test_resources
+    )
+
+    test_job_def = defs.get_job_def("test_job")
+    test_job_def.execute_in_process(
+        tags={
+            "dagster/asset_partition_range_start": "2022-04-10-20:00",
+            "dagster/asset_partition_range_end": "2022-04-10-22:00",
+        },
+        resources=test_resources
+    )
+
+    con = duckdb.connect("test.duckdb")
+    orders_df = con.execute("SELECT * FROM public.orders").fetchdf()
+    os.remove("test.duckdb")
+    assert len(orders_df) == 30
+    
+
+def test_users_multi_partition_backfill():
+    test_job = define_asset_job("test_job", selection=["users"])
+    test_resources = {"io_manager": DuckDBPandasIOManager(database="test.duckdb"), "data_api": data_api.configured({"flaky": False})}
+    defs = Definitions(
+        assets=[users], 
+        jobs=[test_job],
+        resources = test_resources
+    )
+
+    test_job_def = defs.get_job_def("test_job")
+    test_job_def.execute_in_process(
+        tags={
+            "dagster/asset_partition_range_start": "2022-04-10-20:00",
+            "dagster/asset_partition_range_end": "2022-04-10-22:00",
+        },
+        resources=test_resources
+    )
+
+    con = duckdb.connect("test.duckdb")
+    orders_df = con.execute("SELECT * FROM public.users").fetchdf()
+    os.remove("test.duckdb")
+    assert len(orders_df) == 30


### PR DESCRIPTION
This PR makes it possible for a single run to backfill multiple partitions of the orders and users assets.

In order to do this the best approach is to write code that can handle a range of partitions but also works correctly when that "range" is a single partition. 

I also added unit tests for both cases.

Follow on work is needed for the dbt assets to support the same capabilities.

For the sake of sanity, I added an option for the flakiness in the fake data api to be disabled. While this flakiness is useful for demoing dagster's retry policies, it makes unit tests very challenging. If only disabling flakiness were possible for real life.