### PR TITLE
Lopp automaterialize

### DIFF
--- a/dbt_project/models/ANALYTICS/daily_order_summary.sql
+++ b/dbt_project/models/ANALYTICS/daily_order_summary.sql
@@ -1,6 +1,7 @@
 
 {{
         config(
+                dagster_auto_materialize_policy={"type":"lazy"},
                 dagster_freshness_policy={"cron_schedule": "0 9 * * *", "maximum_lag_minutes": 9*60}
         )
 }}

--- a/dbt_project/models/ANALYTICS/order_stats.sql
+++ b/dbt_project/models/ANALYTICS/order_stats.sql
@@ -1,6 +1,14 @@
+{{
+        config(
+                dagster_auto_materialize_policy={"type":"lazy"}
+        )
+}}
 select
         {{ date_trunc("day", "order_date") }} as order_date,
         count(*) as n_orders,
         sum(order_total) as total_revenue
 from {{ ref("orders_augmented") }}
+{% if is_incremental() %}
+WHERE {{ date_trunc("day", "order_date") }} = '{{ var('datetime_to_process') }}'
+{% endif %}
 group by 1

--- a/dbt_project/models/ANALYTICS/sku_stats.sql
+++ b/dbt_project/models/ANALYTICS/sku_stats.sql
@@ -1,3 +1,8 @@
+{{
+        config(
+                dagster_auto_materialize_policy={"type":"lazy"}
+        )
+}}
 select
         order_date,
         sku,

--- a/dbt_project/models/MARKETING/company_perf.sql
+++ b/dbt_project/models/MARKETING/company_perf.sql
@@ -1,3 +1,8 @@
+{{
+        config(
+                dagster_auto_materialize_policy={"type":"lazy"}
+        )
+}}
 select
         company,
         sum(n_orders) as n_orders,

--- a/hooli_data_eng/assets/dbt_assets.py
+++ b/hooli_data_eng/assets/dbt_assets.py
@@ -20,8 +20,8 @@ def dbt_metadata(context, node_info):
 # re-processing all data on each run
 # this approach can be modelled in dagster using partitions 
 # this project includes assets with hourly and daily partitions
-hourly_partitions = HourlyPartitionsDefinition(start_date="2023-04-11-00:00")
-daily_partitions = DailyPartitionsDefinition(start_date="2023-04-12")
+hourly_partitions = HourlyPartitionsDefinition(start_date="2023-05-10-00:00")
+daily_partitions = DailyPartitionsDefinition(start_date="2023-05-11")
 
 def partition_key_to_vars(partition_key):
     """ Map dagster partitions to the dbt var used in our model WHERE clauses """
@@ -82,7 +82,7 @@ daily_dbt_assets = load_assets_from_dbt_project(
     partition_key_to_vars_fn=partition_key_to_vars,
     partitions_def=daily_partitions,
     node_info_to_definition_metadata_fn=io_partition_metadata_fn_order_date,
-    select="daily_order_summary order_stats"
+    select="daily_order_summary order_stats",
 )
 
 dbt_views = load_assets_from_dbt_project(

--- a/hooli_data_eng/assets/dbt_assets.py
+++ b/hooli_data_eng/assets/dbt_assets.py
@@ -21,7 +21,7 @@ def dbt_metadata(context, node_info):
 # this approach can be modelled in dagster using partitions 
 # this project includes assets with hourly and daily partitions
 hourly_partitions = HourlyPartitionsDefinition(start_date="2023-05-10-00:00")
-daily_partitions = DailyPartitionsDefinition(start_date="2023-05-11")
+daily_partitions = DailyPartitionsDefinition(start_date="2023-05-10")
 
 def partition_key_to_vars(partition_key):
     """ Map dagster partitions to the dbt var used in our model WHERE clauses """

--- a/hooli_data_eng/assets/marketing/__init__.py
+++ b/hooli_data_eng/assets/marketing/__init__.py
@@ -1,4 +1,4 @@
-from dagster import asset, FreshnessPolicy, AssetIn, DynamicPartitionsDefinition, MetadataValue
+from dagster import asset, FreshnessPolicy, AssetIn, DynamicPartitionsDefinition, MetadataValue, AutoMaterializePolicy
 import pandas as pd
 
 # These assets take data from a SQL table managed by 
@@ -8,6 +8,7 @@ import pandas as pd
 @asset(
     key_prefix="MARKETING", 
     freshness_policy=FreshnessPolicy(maximum_lag_minutes=240), 
+    auto_materialize_policy=AutoMaterializePolicy.lazy(),
     compute_kind="pandas",
     op_tags={"owner": "bi@hooli.com"}
 )

--- a/hooli_data_eng/assets/raw_data/__init__.py
+++ b/hooli_data_eng/assets/raw_data/__init__.py
@@ -5,7 +5,7 @@ from hooli_data_eng.resources.api import RawDataAPI
 
 
 hourly_partitions = HourlyPartitionsDefinition(
-    start_date="2023-04-11-00:00"
+    start_date="2023-05-10-00:00"
 )
 
 

--- a/hooli_data_eng/definitions.py
+++ b/hooli_data_eng/definitions.py
@@ -108,7 +108,7 @@ resource_def = {
         ),
         "model_io_manager": FilesystemIOManager(),
         "output_notebook_io_manager": ConfigurableLocalOutputNotebookIOManager(),
-        "api": RawDataAPI(),
+        "api": RawDataAPI.configure_at_launch(),
         "s3": ResourceDefinition.none_resource(),
         "dbt": DbtCliClientResource(
             project_dir=DBT_PROJECT_DIR, profiles_dir=DBT_PROFILES_DIR, target="LOCAL"
@@ -133,7 +133,7 @@ resource_def = {
             s3_resource=S3Resource(region_name="us-west-2"),
         ),
         "output_notebook_io_manager": ConfigurableLocalOutputNotebookIOManager(),
-        "api": RawDataAPI(),
+        "api": RawDataAPI.configure_at_launch(),
         "dbt": DbtCliClientResource(
             project_dir=DBT_PROJECT_DIR, profiles_dir=DBT_PROFILES_DIR, target="BRANCH"
         ),
@@ -157,7 +157,7 @@ resource_def = {
             s3_resource=S3Resource(region_name="us-west-2"),
         ),
         "output_notebook_io_manager": ConfigurableLocalOutputNotebookIOManager(),
-        "api": RawDataAPI(),
+        "api": RawDataAPI.configure_at_launch(),
         "dbt": DbtCliClientResource(
             project_dir=DBT_PROJECT_DIR, profiles_dir=DBT_PROFILES_DIR, target="PROD"
         ),

--- a/hooli_data_eng/resources/api.py
+++ b/hooli_data_eng/resources/api.py
@@ -23,6 +23,7 @@ class RawDataAPI(ConfigurableResource):
     @responses.activate
     def get_orders(self, datetime_to_process):
         # add lots of flakiness
+        print(f"Flakiness set to: {self.flaky} with type: {type(self.flaky)}")
         if self.flaky and random.randint(0,10) <= 4:
             raise Exception("API time out")
 

--- a/hooli_data_eng_tests/test_assets.py
+++ b/hooli_data_eng_tests/test_assets.py
@@ -1,6 +1,6 @@
 
 from hooli_data_eng.assets.raw_data import orders, users, hourly_partitions, build_op_context
-from hooli_data_eng.resources.api import data_api
+from hooli_data_eng.resources.api import RawDataAPI
 
 from dagster import define_asset_job, Definitions
 
@@ -11,7 +11,7 @@ import os
 def test_orders_single_partition():
     orders_df = orders(
         build_op_context(
-            resources={"data_api": data_api.configured({"flaky": False})},
+            resources={"api": RawDataAPI(flaky=False)},
             partition_key="2023-04-10-22:00"
         )
     )
@@ -20,7 +20,7 @@ def test_orders_single_partition():
 def test_users_single_partition():
     users_df = users(
         build_op_context(
-            resources={"data_api": data_api.configured({"flaky": False})},
+            resources={"api": RawDataAPI(flaky=False)},
             partition_key="2023-04-10-22:00"
         )
     )
@@ -28,7 +28,7 @@ def test_users_single_partition():
 
 def test_orders_multi_partition_backfill():
     test_job = define_asset_job("test_job", selection=["orders"])
-    test_resources = {"io_manager": DuckDBPandasIOManager(database="test.duckdb"), "data_api": data_api.configured({"flaky": False})}
+    test_resources = {"io_manager": DuckDBPandasIOManager(database="test.duckdb"), "api": RawDataAPI(flaky=False)}
     defs = Definitions(
         assets=[orders], 
         jobs=[test_job],
@@ -52,7 +52,7 @@ def test_orders_multi_partition_backfill():
 
 def test_users_multi_partition_backfill():
     test_job = define_asset_job("test_job", selection=["users"])
-    test_resources = {"io_manager": DuckDBPandasIOManager(database="test.duckdb"), "data_api": data_api.configured({"flaky": False})}
+    test_resources = {"io_manager": DuckDBPandasIOManager(database="test.duckdb"), "api": RawDataAPI(flaky=False)}
     defs = Definitions(
         assets=[users], 
         jobs=[test_job],


### PR DESCRIPTION
This PR does a few things

1. Deprecates the reconciliation sensor in favor of the AutoMaterialize policies
2. Fixes the unit tests for the user and order assets which were broken by the resource config re-write
3. Resets the partition definitions to a later date

The change to (1) should also dramatically simplify the behavior we're seeing on hooli where the root assets were being updated by both a schedule and freshness sensor, causing confusing discrepancies between run statuses and partition statuses.