### PR TITLE
make amps work better for hooli

### DIFF
--- a/dbt_project/models/ANALYTICS/company_stats.sql
+++ b/dbt_project/models/ANALYTICS/company_stats.sql
@@ -1,8 +1,3 @@
-{{
-        config(
-                dagster_auto_materialize_policy={"type":"lazy"}
-        )
-}}
 select
         order_date,
         company,

--- a/dbt_project/models/ANALYTICS/order_stats.sql
+++ b/dbt_project/models/ANALYTICS/order_stats.sql
@@ -1,8 +1,3 @@
-{{
-        config(
-                dagster_auto_materialize_policy={"type":"eager"}
-        )
-}}
 select
         {{ date_trunc("day", "order_date") }} as order_date,
         count(*) as n_orders,

--- a/dbt_project/models/ANALYTICS/sku_stats.sql
+++ b/dbt_project/models/ANALYTICS/sku_stats.sql
@@ -1,8 +1,3 @@
-{{
-        config(
-                dagster_auto_materialize_policy={"type":"eager"}
-        )
-}}
 select
         order_date,
         sku,

--- a/dbt_project/models/ANALYTICS/weekly_order_summary.sql
+++ b/dbt_project/models/ANALYTICS/weekly_order_summary.sql
@@ -1,7 +1,6 @@
 
 {{
         config(
-                dagster_auto_materialize_policy={"type":"eager"},
                 dagster_freshness_policy={"cron_schedule": "0 9 * * MON", "maximum_lag_minutes": (24+9)*60}
         )
 }}

--- a/dbt_project/models/MARKETING/company_perf.sql
+++ b/dbt_project/models/MARKETING/company_perf.sql
@@ -1,8 +1,3 @@
-{{
-        config(
-                dagster_auto_materialize_policy={"type":"lazy"}
-        )
-}}
 select
         company,
         sum(n_orders) as n_orders,

--- a/hooli_data_eng/assets/dbt_assets.py
+++ b/hooli_data_eng/assets/dbt_assets.py
@@ -7,6 +7,8 @@ from dagster_dbt import (
 )
 from dagster_dbt.asset_decorator import dbt_assets
 from dagster import (
+    AutoMaterializePolicy,
+    AutoMaterializeRule,
     AssetKey,
     DailyPartitionsDefinition,
     WeeklyPartitionsDefinition,
@@ -35,6 +37,15 @@ DBT_MANIFEST = Path(
     file_relative_path(__file__, "../../dbt_project/target/manifest.json")
 )
 
+allow_outdated_parents_policy = AutoMaterializePolicy.eager().without_rules(
+    AutoMaterializeRule.skip_on_parent_outdated()
+)
+
+allow_outdated_and_missing_parents_policy = AutoMaterializePolicy.eager().without_rules(
+    AutoMaterializeRule.skip_on_parent_outdated(), 
+    AutoMaterializeRule.skip_on_parent_missing() # non-partitioned assets should run even if some upstream partitions are missing
+)
+
 
 class CustomDagsterDbtTranslator(DagsterDbtTranslator):
     def get_description(self, dbt_resource_props: Mapping[str, Any]) -> str:
@@ -51,6 +62,9 @@ class CustomDagsterDbtTranslator(DagsterDbtTranslator):
         if node_path == "models/sources.yml":
             prefix = "RAW_DATA"
 
+        if node_path == "MARKETING/company_perf.sql":
+            prefix = "ANALYTICS"
+
         return AssetKey([prefix, dbt_resource_props["name"]])
 
     def get_group_name(self, dbt_resource_props: Mapping[str, Any]):
@@ -59,6 +73,9 @@ class CustomDagsterDbtTranslator(DagsterDbtTranslator):
 
         if node_path == "models/sources.yml":
             prefix = "RAW_DATA"
+
+        if node_path == "MARKETING/company_perf.sql":
+            prefix = "ANALYTICS"
 
         return prefix
 
@@ -71,10 +88,24 @@ class CustomDagsterDbtTranslator(DagsterDbtTranslator):
         if dbt_resource_props["name"] == "users_cleaned":
             metadata = {"partition_expr": "created_at"}
 
+        if dbt_resource_props["name"] in ["company_perf", "sku_stats", "company_stats"]:
+            metadata = {}
+
         default_metadata = default_metadata_from_dbt_resource_props(dbt_resource_props)
 
         return {**default_metadata, **metadata}
 
+    def get_auto_materialize_policy(
+        self, dbt_resource_props: Mapping[str, Any]
+    ):
+        return allow_outdated_parents_policy
+
+
+class CustomDagsterDbtTranslatorForViews(CustomDagsterDbtTranslator):
+    def get_auto_materialize_policy(
+        self, dbt_resource_props: Mapping[str, Any]
+    ):
+        return allow_outdated_and_missing_parents_policy
 
 def _process_partitioned_dbt_assets(context: OpExecutionContext, dbt2: DbtCliResource):
     # map partition key range to dbt vars
@@ -145,8 +176,9 @@ def weekly_dbt_assets(context: OpExecutionContext, dbt2: DbtCliResource):
 dbt_views = load_assets_from_dbt_project(
     DBT_PROJECT_DIR,
     DBT_PROFILES_DIR,
-    key_prefix=["ANALYTICS"],
-    source_key_prefix="ANALYTICS",
+    #key_prefix=["ANALYTICS"],
+    #source_key_prefix="ANALYTICS",
     select="company_perf sku_stats company_stats",
-    node_info_to_group_fn=lambda x: "ANALYTICS",
+    #node_info_to_group_fn=lambda x: "ANALYTICS",
+    dagster_dbt_translator=CustomDagsterDbtTranslatorForViews()
 )

--- a/hooli_data_eng/assets/marketing/__init__.py
+++ b/hooli_data_eng/assets/marketing/__init__.py
@@ -11,6 +11,8 @@ from dagster import (
 )
 import pandas as pd
 
+from hooli_data_eng.assets.dbt_assets import allow_outdated_parents_policy
+
 # These assets take data from a SQL table managed by 
 # dbt and create summaries using pandas 
 # The assets are updated via freshness policies 
@@ -18,7 +20,7 @@ import pandas as pd
 @asset(
     key_prefix="MARKETING", 
     freshness_policy=FreshnessPolicy(maximum_lag_minutes=24*60), 
-    auto_materialize_policy=AutoMaterializePolicy.lazy(),
+    auto_materialize_policy=allow_outdated_parents_policy,
     compute_kind="pandas",
     op_tags={"owner": "bi@hooli.com"},
     ins={"company_perf": AssetIn(key_prefix=["ANALYTICS"])}


### PR DESCRIPTION
This PR addresses some long standing problem's in Hooli's use of experimental auto-materialization policies, specifically the case of daily partitioned assets -> weekly partitioned assets -> unpartitioned assets. 

The customized policy now makes it so that any change to a daily partition will cause downstream assets to materialize, essentially making AMPs more aggressive. This change helps us demo how changes propagate through the system. 

We also remove lazy policies which just didn't work in these situations.

Tradeoffs:

The remaining freshness policies are now useful for alerting only, they no longer dictate run behavior.

The change to use a customized AMP means the AMP policies must be defined in code and not in the dbt model config.
