### PR TITLE
WIP adding dbt slim CI job

### DIFF
--- a/.github/workflows/deploy-dagster-cloud.yml
+++ b/.github/workflows/deploy-dagster-cloud.yml
@@ -182,7 +182,7 @@ jobs:
 
       # Trigger dbt slim CI job
       - name: Trigger dbt slim CI
-        if: steps.prerun.outputs.result != 'skip' && github.event.action == 'pull_request'
+        if: steps.prerun.outputs.result != 'skip' && github.event_name == 'pull_request'
         uses: dagster-io/dagster-cloud-action/actions/utils/run@v0.1
         with:
           location_name: data-eng-pipeline

--- a/.github/workflows/deploy-dagster-cloud.yml
+++ b/.github/workflows/deploy-dagster-cloud.yml
@@ -180,13 +180,21 @@ jobs:
         with:
           command: "ci deploy"
 
+      # Get branch deployment as input to job trigger below
+      - name: Get branch deployment
+        id: get-branch-deployment
+        if: github.event.action == 'opened' || github.event.action == 'reopened'
+        uses: dagster-io/dagster-cloud-action/actions/utils/get_branch_deployment@v0.1
+        with:
+          organization_id: 'hooli'
+
       # Trigger dbt slim CI job
       - name: Trigger dbt slim CI
         if: steps.prerun.outputs.result != 'skip' && github.event_name == 'pull_request'
         uses: dagster-io/dagster-cloud-action/actions/utils/run@v0.1
         with:
-          location_name: ${{ matrix.location.name }}
-          deployment: ${{ steps.deploy.outputs.deployment }}
+          location_name: data-eng-pipeline
+          deployment: ${{ steps.get-branch-deployment.outputs.deployment }}
           job_name: dbt_slim_ci_job
           organization_id: hooli
 

--- a/.github/workflows/deploy-dagster-cloud.yml
+++ b/.github/workflows/deploy-dagster-cloud.yml
@@ -13,7 +13,6 @@ concurrency:
   cancel-in-progress: true
 env:
   DAGSTER_CLOUD_ORGANIZATION: "hooli"
-  DAGSTER_CLOUD_URL: ${{ secrets.DAGSTER_CLOUD_URL }}
   DAGSTER_CLOUD_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
   DAGSTER_PROJECT_DIR: "."
   DAGSTER_CLOUD_YAML_PATH: "dagster_cloud.yaml"
@@ -67,11 +66,7 @@ jobs:
         if: ${{ steps.prerun.outputs.result != 'skip' }}
         uses: aws-actions/amazon-ecr-login@v1
 
-      # Use AWS CLI to copy the dbt manifest.json to or from S3 for slim CI
-      - name: Setup AWS CLI
-        if: steps.prerun.outputs.result != 'skip'
-        uses: aws-actions/setup-aws-cli@v2
-
+      # Copy the production manifest.json to local directory - Raise error if not retrieved
       - name: Download dbt manifest from S3
         if: steps.prerun.outputs.result != 'skip' && github.event_name == 'pull_request'
         continue-on-error: true
@@ -83,6 +78,7 @@ jobs:
         if: steps.prerun.outputs.result != 'skip'
         run: make manifest
 
+      # Copy production manifest.json to S3 on merge
       - name: Upload dbt manifest to S3
         if: steps.prerun.outputs.result != 'skip' && github.event.pull_request.merged == true
         run: |
@@ -189,9 +185,9 @@ jobs:
         if: github.event.action != 'pull_request'
         uses: dagster-io/dagster-cloud-action/actions/utils/run@v0.1
         with:
-          location_name: ${{ matrix.location.name }}
-          deployment: ${{ steps.deploy.outputs.deployment }}
-          job: dbt_slim_ci_job
+          location_name: data-eng-pipeline
+          deployment: data-eng-prod
+          job_name: dbt_slim_ci_job
 
       # Summary and comment updates - note these always() run
       - name: Update PR comment for branch deployments

--- a/.github/workflows/deploy-dagster-cloud.yml
+++ b/.github/workflows/deploy-dagster-cloud.yml
@@ -183,7 +183,7 @@ jobs:
       # Get branch deployment as input to job trigger below
       - name: Get branch deployment
         id: get-branch-deployment
-        if: github.event.action == 'opened' || github.event.action == 'reopened'
+        if: steps.prerun.outputs.result != 'skip' && github.event_name == 'pull_request'
         uses: dagster-io/dagster-cloud-action/actions/utils/get_branch_deployment@v0.1
         with:
           organization_id: 'hooli'

--- a/.github/workflows/deploy-dagster-cloud.yml
+++ b/.github/workflows/deploy-dagster-cloud.yml
@@ -13,6 +13,7 @@ concurrency:
   cancel-in-progress: true
 env:
   DAGSTER_CLOUD_ORGANIZATION: "hooli"
+  DAGSTER_CLOUD_URL: ${{ secrets.DAGSTER_CLOUD_URL }}
   DAGSTER_CLOUD_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
   DAGSTER_PROJECT_DIR: "."
   DAGSTER_CLOUD_YAML_PATH: "dagster_cloud.yaml"
@@ -66,10 +67,26 @@ jobs:
         if: ${{ steps.prerun.outputs.result != 'skip' }}
         uses: aws-actions/amazon-ecr-login@v1
 
+      # Use AWS CLI to copy the dbt manifest.json to or from S3 for slim CI
+      - name: Setup AWS CLI
+        if: steps.prerun.outputs.result != 'skip'
+        uses: aws-actions/setup-aws-cli@v2
+
+      - name: Download dbt manifest from S3
+        if: steps.prerun.outputs.result != 'skip' && github.event_name == 'pull_request'
+        continue-on-error: true
+        run: |
+          output=$(aws s3 cp s3://hooli-demo/dbt_slim_ci/manifest.json ./dbt_project/target/slim_ci/manifest.json 2>&1) || echo "Error: $output"
+
       # Build 'data-eng-pipeline' code location
       - name: Build dbt manifest for data-eng-pipeline
         if: steps.prerun.outputs.result != 'skip'
         run: make manifest
+
+      - name: Upload dbt manifest to S3
+        if: steps.prerun.outputs.result != 'skip' && github.event.pull_request.merged == true
+        run: |
+          aws s3 cp ./dbt_project/target/manifest.json s3://hooli-demo/dbt_slim_ci/manifest.json
 
       - name: Build and upload Docker image for data-eng-pipeline
         if: steps.prerun.outputs.result != 'skip'
@@ -166,6 +183,15 @@ jobs:
         uses: dagster-io/dagster-cloud-action/actions/utils/dagster-cloud-cli@v0.1.27
         with:
           command: "ci deploy"
+
+      # Trigger dbt slim CI job
+      - name: Trigger dbt slim CI
+        if: github.event.action != 'pull_request'
+        uses: dagster-io/dagster-cloud-action/actions/utils/run@v0.1
+        with:
+          location_name: ${{ matrix.location.name }}
+          deployment: ${{ steps.deploy.outputs.deployment }}
+          job: dbt_slim_ci_job
 
       # Summary and comment updates - note these always() run
       - name: Update PR comment for branch deployments

--- a/.github/workflows/deploy-dagster-cloud.yml
+++ b/.github/workflows/deploy-dagster-cloud.yml
@@ -185,8 +185,8 @@ jobs:
         if: steps.prerun.outputs.result != 'skip' && github.event_name == 'pull_request'
         uses: dagster-io/dagster-cloud-action/actions/utils/run@v0.1
         with:
-          location_name: data-eng-pipeline
-          deployment: data-eng-prod
+          location_name: ${{ matrix.location.name }}
+          deployment: ${{ steps.deploy.outputs.deployment }}
           job_name: dbt_slim_ci_job
           organization_id: hooli
 

--- a/.github/workflows/deploy-dagster-cloud.yml
+++ b/.github/workflows/deploy-dagster-cloud.yml
@@ -182,7 +182,7 @@ jobs:
 
       # Trigger dbt slim CI job
       - name: Trigger dbt slim CI
-        if: github.event.action != 'pull_request'
+        if: steps.prerun.outputs.result != 'skip' && github.event.action == 'pull_request'
         uses: dagster-io/dagster-cloud-action/actions/utils/run@v0.1
         with:
           location_name: data-eng-pipeline

--- a/.github/workflows/deploy-dagster-cloud.yml
+++ b/.github/workflows/deploy-dagster-cloud.yml
@@ -188,6 +188,7 @@ jobs:
           location_name: data-eng-pipeline
           deployment: data-eng-prod
           job_name: dbt_slim_ci_job
+          organization_id: hooli
 
       # Summary and comment updates - note these always() run
       - name: Update PR comment for branch deployments

--- a/hooli_data_eng/assets/dbt_assets.py
+++ b/hooli_data_eng/assets/dbt_assets.py
@@ -163,7 +163,7 @@ dbt_views = load_assets_from_dbt_project(
 # This op will be used to run slim CI
 @op
 def dbt_slim_ci(dbt2: DbtCliResource):
-    slim_ci_manifest = SLIM_CI_MANIFEST if SLIM_CI_MANIFEST.exists() else DBT_MANIFEST 
+    slim_ci_manifest = SLIM_CI_MANIFEST if SLIM_CI_MANIFEST.exists() else DBT_MANIFEST.parent 
 
     dbt_command = [
         "build",

--- a/hooli_data_eng/assets/forecasting/__init__.py
+++ b/hooli_data_eng/assets/forecasting/__init__.py
@@ -49,8 +49,8 @@ CONTAINER_REGISTRY = (
 class modelHyperParams(Config):
     """Hyper parameters for the ML model with default values"""
 
-    a_init = Field(5, description="initial value for a parameter, intercept")
-    b_init = Field(5, description="initial value for b parameter, slope")
+    a_init: float = Field(5, description="initial value for a parameter, intercept")
+    b_init: float = Field(5, description="initial value for b parameter, slope")
 
 
 @asset(

--- a/hooli_data_eng/definitions.py
+++ b/hooli_data_eng/definitions.py
@@ -7,6 +7,7 @@ from dagster import (
 )
 
 from hooli_data_eng.assets import forecasting, raw_data, marketing, dbt_assets
+from hooli_data_eng.assets.dbt_assets import dbt_slim_ci_job
 from hooli_data_eng.assets.marketing import check_avg_orders
 from hooli_data_eng.assets.raw_data import check_users
 from hooli_data_eng.jobs import analytics_job, predict_job
@@ -69,5 +70,5 @@ defs = Definitions(
        watch_s3_sensor,
        asset_delay_alert_sensor,
     ],
-    jobs=[analytics_job, predict_job],
+    jobs=[analytics_job, predict_job, dbt_slim_ci_job],
 )


### PR DESCRIPTION
Adding dbt slim CI functionality.  

High level process:

- Copy production manifest.json to S3
- Created @op and @job to use dbt's state deferral syntax (e.g., dbt build --select state:modified+ --defer --state <path/to/prod_manifest.json> ), since assets don't currently support it

- GitHub Action:
  - Reads production manifest.json from S3 
  - Generates new manifest.json with code changes
  - Triggers op job above using the two manifests for comparison and only materialize new dbt models + downstream dependencies