### PR TITLE
update dagster asset check to fail"better"

### DIFF
--- a/hooli_data_eng/assets/raw_data/__init__.py
+++ b/hooli_data_eng/assets/raw_data/__init__.py
@@ -58,21 +58,25 @@ def users(context, api: RawDataAPI) -> pd.DataFrame:
         description="check that users are from expected companies",
 )
 def check_users(context, users: pd.DataFrame):
-    unique_companies = set(pd.unique(users['company']))
+    observed_companies = set(pd.unique(users['company']))
     expected_companies = {"ShopMart", "SportTime", "FamilyLtd", "DiscountStore"}
 
-    asset_check_output ={"observed_companies": list(unique_companies),
+    asset_check_output ={"observed_companies": list(observed_companies),
                         "expected_comanies": list(expected_companies),
-                        "in_observed_not_expected": list(unique_companies - expected_companies),
-                        "in_expected_not_observed": list(expected_companies - unique_companies)
+                        "in_observed_not_expected": list(observed_companies - expected_companies),
+                        "in_expected_not_observed": list(expected_companies - observed_companies)
     }
 
     df = pd.DataFrame({key: pd.Series(value) for key, value in asset_check_output.items() })
 
     return AssetCheckResult(
-        passed=  (set(unique_companies) == expected_companies),
-        metadata={"result": MetadataValue.md(df.to_markdown())
-                  },
+        passed=  (set(observed_companies) == expected_companies),
+        metadata={"result": MetadataValue.md(
+            f"""
+                Observed the following unexpected companies: 
+                {list(observed_companies - expected_companies)}
+            """
+        )},
         severity=AssetCheckSeverity.WARN
     )
 

--- a/hooli_data_eng/assets/raw_data/__init__.py
+++ b/hooli_data_eng/assets/raw_data/__init__.py
@@ -61,14 +61,6 @@ def check_users(context, users: pd.DataFrame):
     observed_companies = set(pd.unique(users['company']))
     expected_companies = {"ShopMart", "SportTime", "FamilyLtd", "DiscountStore"}
 
-    asset_check_output ={"observed_companies": list(observed_companies),
-                        "expected_comanies": list(expected_companies),
-                        "in_observed_not_expected": list(observed_companies - expected_companies),
-                        "in_expected_not_observed": list(expected_companies - observed_companies)
-    }
-
-    df = pd.DataFrame({key: pd.Series(value) for key, value in asset_check_output.items() })
-
     return AssetCheckResult(
         passed=  (set(observed_companies) == expected_companies),
         metadata={"result": MetadataValue.md(


### PR DESCRIPTION
This PR updates the asset check on the `RAW_DATA.users` asset in a few ways

*  compares the types to a set (previously it would almost always fail because lists are unordered)
* forces it to fail by omitting one of the observed companies in the expected companies, _and_ by adding an expected company that is not in observed
* **this one I want feedback on** -- I added a markdown data element (see the image below) after following along with some of the cool metadata output types @slopp wrote up [in this GitHub Discussion](https://github.com/dagster-io/dagster/discussions/15409). I wanted to show the "in expected not observed" and "in observed not expected" in some sort of way to show off how powerful the metadata exposures can be, but the data frame --> markdown I did here leaves a lot to be desired.

<img width="657" alt="image" src="https://github.com/dagster-io/hooli-data-eng-pipelines/assets/12430096/a1242ede-ccbb-4722-97e9-5c8a815194db">

Will pull this out of draft mode once we get some consensus on the metadata output for this