### PR TITLE
update owners to new asset owners

### DIFF
--- a/hooli_data_eng/assets/dbt_assets.py
+++ b/hooli_data_eng/assets/dbt_assets.py
@@ -93,13 +93,10 @@ class CustomDagsterDbtTranslator(DagsterDbtTranslator):
         metadata = {"partition_expr": "order_date"}
 
         if dbt_resource_props["name"] == "orders_cleaned":
-            metadata = {"partition_expr": "dt", "owner":"data@hooli.org"}
+            metadata = {"partition_expr": "dt"}
 
         if dbt_resource_props["name"] == "users_cleaned":
-            metadata = {"partition_expr": "created_at", "owner":"data@hooli.org"}
-
-        if dbt_resource_props["name"] in ["company_perf", "sku_stats", "company_stats"]:
-            metadata = {"owner":"bi@hooli.org"}
+            metadata = {"partition_expr": "created_at"}
 
         default_metadata = default_metadata_from_dbt_resource_props(dbt_resource_props)
 

--- a/hooli_data_eng/assets/marketing/__init__.py
+++ b/hooli_data_eng/assets/marketing/__init__.py
@@ -22,7 +22,7 @@ from hooli_data_eng.assets.dbt_assets import allow_outdated_parents_policy
     freshness_policy=FreshnessPolicy(maximum_lag_minutes=24*60), 
     auto_materialize_policy=allow_outdated_parents_policy,
     compute_kind="pandas",
-    op_tags={"owner": "bi@hooli.com"},
+    owners=["team:programmers", "lopp@dagsterlabs.com"],
     ins={"company_perf": AssetIn(key_prefix=["ANALYTICS"])}
 )
 def avg_orders(context: AssetExecutionContext, company_perf: pd.DataFrame) -> pd.DataFrame:
@@ -47,9 +47,7 @@ def check_avg_orders(context, avg_orders: pd.DataFrame):
     key_prefix="MARKETING", 
     freshness_policy=FreshnessPolicy(maximum_lag_minutes=24*60), 
     compute_kind="snowflake", 
-    metadata={
-        "owner": "bi@hooli.com"
-    },
+    owners=["team:programmers"],
     ins={"company_perf": AssetIn(key_prefix=["ANALYTICS"])}
 )
 def min_order(context, company_perf: pd.DataFrame) -> pd.DataFrame:


### PR DESCRIPTION
This PR adopts the new asset `owners` field which allows for asset alerts and populates the `owners` information in the new asset details view

Still TBD: 
- [ ] How to add owners to `dbt_assets` 
- [ ] Whether we're [happy with the approach to adding ourselves instead of fictional owners to the platform](https://dagsterlabs.slack.com/archives/C06LXCWV7LP/p1710343473297619)
- [ ] Whether we want to add owners for every asset, or at least more of them