### PR TITLE
add local dev and update docs for Sling

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ To understand the structure, start with the file `hooli_data_eng/definitions.py`
 - *Retries* are enabled for both runs and assets, making the pipeline robust to occassional flakiness. See `hooli_data_eng/definitions.py` for examples of retries on jobs, and `hooli_data_eng/assets/marketing/__init__.py` for an example of a more complex retry policy on an asset including backoff and jitter. Flakiness is generated in `hooli_data_eng/resources/api.py`.
 - *Alerts* are enabled through Dagster Clould alert policies based on job tags. A custom alert is also specified to notify when assets with SLAs are later than expected. See `hooli_data_eng/assets/delayed_asset_alerts.py`. 
 
+## Assets spanning Multiple Code Locations
+
+- to run the `locations` dataset, uncomment out line 5-7 in [workspaces.yml](workspaces.yml)
+- you will also need to install the packages in the "sling" extra (e.g. `pip install -e ".[dev,sling]")`)
+- You'll need to obtain the credentials for AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+- then run `dagster dev` and both `hooli_demo_assets` and `hooli_data_eng` code locations will load
+
 ## Deployment Architecture 
 
 This repository uses Dagster Cloud Hybrid architecture with GitHub Actions to provide CI/CD.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ To understand the structure, start with the file `hooli_data_eng/definitions.py`
 - you will also need to install the packages in the "sling" extra (e.g. `pip install -e ".[dev,sling]")`)
 - You'll need to obtain the credentials for AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
 - then run `dagster dev` and both `hooli_demo_assets` and `hooli_data_eng` code locations will load
+- NOTE: if you are running Sling locally, there is currently an error message if you already have a duckdb database set up the first time you run the Sling integration. You'll need to delete it and have the `location` asset be the the first thing you materialize.
 
 ## Deployment Architecture 
 

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,6 @@ if __name__ == "__main__":
             "html5lib",
             "scikit-learn",
         ],
-        extras_require={"dev": ["dagit", "pytest"]},
+        extras_require={"dev": ["dagster-webserver", "pytest"],
+                        "sling": ["dagster-embedded-elt"]},
     )


### PR DESCRIPTION
the Sling loader was failing in prod, and I wanted to debug it. There must have been an update to Sling between version upgrades because we needed to change the AWS_BUCKET from `s3://{bucket_name}/{folder_path}` (old) to just `{bucket_name}`. That was an env var change which is now live, but for me to figure that out I had to get the local version working. This PR adds that local support:

* updates the extras in `setup.py` to include `dagster-embedded-elt`
* adds a local duckdb target and makes local dev supportable
* updates the README.md