### PR TITLE
use PROD target for makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ clean:
 	rm -rf ~/.dagster_home; mkdir ~/.dagster_home; cp dagster.yaml ~/.dagster_home/dagster.yaml
 
 manifest:
-	dbt parse --project-dir=dbt_project --profiles-dir=dbt_project/config --target BRANCH
+	dbt parse --project-dir=dbt_project --profiles-dir=dbt_project/config --target PROD
 
 deps:
 	dbt deps --project-dir=dbt_project --profiles-dir=dbt_project/config


### PR DESCRIPTION
We need to use the PROD version of the manifest for certain features to be enabled in prod (such as column-level-lineage). This is somewhat temporary since we will eventually have other options based on some of the upcoming dagster-dbt feartures coming up