### PR TITLE
fix partition mismatch for dbt

### DIFF
--- a/hooli_data_eng/assets/dbt_assets.py
+++ b/hooli_data_eng/assets/dbt_assets.py
@@ -153,11 +153,9 @@ def weekly_dbt_assets(context: OpExecutionContext, dbt2: DbtCliResource):
 @dbt_assets(
     manifest=DBT_MANIFEST,
     select="company_perf sku_stats company_stats locations_cleaned",
-    partitions_def=weekly_partitions,
     dagster_dbt_translator=CustomDagsterDbtTranslatorForViews(
         DagsterDbtTranslatorSettings(enable_asset_checks=True)
     ),
-    backfill_policy=BackfillPolicy.single_run(),
 )
 def views_dbt_assets(context: OpExecutionContext, dbt2: DbtCliResource):
     # Invoke dbt CLI


### PR DESCRIPTION
when we refactored the code to remove the older dbt APIs, we accidentally made our dbt views into weekly partitioned assets, which causes problems since they are upstream of some daily partitioned assets