### PR TITLE
add insights extra to dasgter-cloud

### DIFF
--- a/hooli-demo-assets/setup.py
+++ b/hooli-demo-assets/setup.py
@@ -5,7 +5,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         "dagster",
-        "dagster-cloud",
+        "dagster-cloud[insights]",
         "dagster-embedded-elt",
     ],
     extras_require={"dev": ["dagit", "pytest"]},

--- a/hooli_basics/requirements.txt
+++ b/hooli_basics/requirements.txt
@@ -2,4 +2,4 @@ pandas
 html5lib
 scikit-learn
 dagster
-dagster-cloud
+dagster-cloud[insights]

--- a/hooli_batch_enrichment/setup.py
+++ b/hooli_batch_enrichment/setup.py
@@ -8,7 +8,7 @@ setup(
         "dagster-duckdb",
         "pandas",
         "responses",
-        "dagster-cloud"
+        "dagster-cloud[insights]"
     ],
     extras_require={"dev": ["dagit", "pytest"]},
 )

--- a/hooli_snowflake_insights/requirements.txt
+++ b/hooli_snowflake_insights/requirements.txt
@@ -1,5 +1,5 @@
 dagster
-dagster-cloud
+dagster-cloud[insights]
 dagster-dbt
 dagster-snowflake
 gql

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
             "dagster-duckdb-pandas",
             "dagster-snowflake",
             "dagster-snowflake-pandas",
-            "dagster-cloud",
+            "dagster-cloud[insights]",
             "dagster-pyspark",
             "dagster-databricks",
             "dagster-k8s",


### PR DESCRIPTION
adds dagster-cloud[insights] extra to all installs of dagster-cloud. We might only need it in `hooli_snowflake_insights`, and it's redundant for `hooli_data_eng` because it already has pyarrow from other dependencies