### PR TITLE
bump dagster version to 1.7.8

### DIFF
--- a/dbt_project/packages.yml
+++ b/dbt_project/packages.yml
@@ -3,4 +3,4 @@ packages:
     version: 0.10.3
   - git: "https://github.com/dagster-io/dagster.git"
     subdirectory: "python_modules/libraries/dagster-dbt/dbt_packages/dagster"
-    revision: "1.7.5" # replace with the version of `dagster` you are using.
+    revision: "1.7.8" # replace with the version of `dagster` you are using.


### PR DESCRIPTION
brings us plotting of number of failures for dbt test results

Looks like this 

<img width="1284" alt="image" src="https://github.com/dagster-io/hooli-data-eng-pipelines/assets/12430096/7cc45e42-352d-47bb-b8cf-5e26ec947853">

and will also show up in insights