### PR TITLE
Add storage_kind tag

### DIFF
--- a/hooli_data_eng/assets/forecasting/__init__.py
+++ b/hooli_data_eng/assets/forecasting/__init__.py
@@ -167,6 +167,7 @@ def predicted_orders(
     key_prefix=["FORECASTING"],
     required_resource_keys={"step_launcher", "pyspark"},
     metadata={"resource_constrained_at": 50},
+    tags={**StorageKindTagSet(storage_kind="databricks")},
 )
 def big_orders(context, predicted_orders: pd.DataFrame):
     """Days where predicted orders surpass our current carrying capacity"""
@@ -195,6 +196,7 @@ model_nb = define_dagstermill_asset(
 @asset(
     deps=[predicted_orders],
     compute_kind="databricks",
+    tags={**StorageKindTagSet(storage_kind="databricks")},
 )
 def databricks_asset(
     context: AssetExecutionContext,

--- a/hooli_data_eng/assets/marketing/__init__.py
+++ b/hooli_data_eng/assets/marketing/__init__.py
@@ -1,3 +1,5 @@
+import datetime
+
 from dagster import (
     asset,
     build_last_update_freshness_checks,
@@ -9,16 +11,20 @@ from dagster import (
     AssetCheckResult,
     asset_check,
     AssetKey,
-    FreshnessPolicy,
     define_asset_job, 
     ScheduleDefinition,
     AssetSelection
 )
-import pandas as pd
-import datetime
+from dagster._core.definitions.tags import StorageKindTagSet
 from dagster_cloud.anomaly_detection import build_anomaly_detection_freshness_checks
+import pandas as pd
 
 from hooli_data_eng.assets.dbt_assets import allow_outdated_parents_policy
+from hooli_data_eng.utils.config_utils import get_storage_kind
+
+
+# dynamically determine storage_kind based on environment
+storage_kind = get_storage_kind()
 
 
 # These assets take data from a SQL table managed by
@@ -29,6 +35,7 @@ from hooli_data_eng.assets.dbt_assets import allow_outdated_parents_policy
     compute_kind="pandas",
     owners=["team:programmers", "lopp@dagsterlabs.com"],
     ins={"company_perf": AssetIn(key_prefix=["ANALYTICS"])},
+    tags={**StorageKindTagSet(storage_kind=storage_kind)},
 )
 def avg_orders(
     context: AssetExecutionContext, company_perf: pd.DataFrame
@@ -73,6 +80,7 @@ product_skus = DynamicPartitionsDefinition(name="product_skus")
     compute_kind="hex",
     key_prefix="MARKETING",
     ins={"sku_stats": AssetIn(key_prefix=["ANALYTICS"])},
+    tags={**StorageKindTagSet(storage_kind="s3")},
 )
 def key_product_deepdive(context, sku_stats):
     """Creates a file for a BI tool based on the current quarters top product, represented as a dynamic partition"""

--- a/hooli_data_eng/assets/marketing/__init__.py
+++ b/hooli_data_eng/assets/marketing/__init__.py
@@ -58,7 +58,7 @@ def check_avg_orders(context, avg_orders: pd.DataFrame):
 
 @asset(
     key_prefix="MARKETING",
-    compute_kind="snowflake",
+    compute_kind="pandas",
     owners=["team:programmers"],
     ins={"company_perf": AssetIn(key_prefix=["ANALYTICS"])},
     tags={**StorageKindTagSet(storage_kind=storage_kind)},

--- a/hooli_data_eng/assets/marketing/__init__.py
+++ b/hooli_data_eng/assets/marketing/__init__.py
@@ -61,6 +61,7 @@ def check_avg_orders(context, avg_orders: pd.DataFrame):
     compute_kind="snowflake",
     owners=["team:programmers"],
     ins={"company_perf": AssetIn(key_prefix=["ANALYTICS"])},
+    tags={**StorageKindTagSet(storage_kind=storage_kind)},
 )
 def min_order(context, company_perf: pd.DataFrame) -> pd.DataFrame:
     """Computes min order KPI"""

--- a/hooli_data_eng/utils/config_utils.py
+++ b/hooli_data_eng/utils/config_utils.py
@@ -1,0 +1,15 @@
+import os
+
+def get_storage_kind() -> str:
+    """
+    Determine the storage kind based on the environment.
+
+    Returns:
+        str: The storage kind ('snowflake' or 'duckdb').
+    """
+    if (
+        os.getenv("DAGSTER_CLOUD_DEPLOYMENT_NAME", "") == "data-eng-prod" or 
+        os.getenv("DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT", "") == "1"
+    ):
+        return "snowflake"
+    return "duckdb"


### PR DESCRIPTION
Adding `storage_kind` to non-dbt assets in the `hooli_data_eng` code location.

Summary of changes:

- Added `config_utils.py` to dynamically generate storage_kind (duckdb or snowflake) based on deployment (local or branch/prod)
- Added storage_kind to non-dbt assets where the `compute_kind` didn't make this obvious

One thing to note, I defaulted the storage_kind to S3 for assets using the `model_io_manager` since it uses the `FilesystemIOManager()` locally and S3 in branch and prod deployments.