### PR TITLE
bump versions and add caching

### DIFF
--- a/.github/workflows/deploy-dagster-cloud.yml
+++ b/.github/workflows/deploy-dagster-cloud.yml
@@ -28,7 +28,7 @@ jobs:
         uses: dagster-io/dagster-cloud-action/actions/utils/prerun@v0.1.38
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         if: steps.prerun.outputs.result != 'skip'
         with:
           ref: ${{ github.head_ref }}
@@ -54,8 +54,11 @@ jobs:
         if: steps.prerun.outputs.result != 'skip'
         run: echo "IMAGE_TAG=$GITHUB_SHA-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT" >> $GITHUB_ENV && echo $IMAGE_TAG
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         if: steps.prerun.outputs.result != 'skip'
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -64,7 +67,8 @@ jobs:
 
       - name: Login to ECR
         if: ${{ steps.prerun.outputs.result != 'skip' }}
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
+        with: mask-password: 'true'
 
       - name: Set Branch Deployment Environment Variable for PR
         if: steps.prerun.outputs.result != 'skip' && github.event_name == 'pull_request'
@@ -85,11 +89,13 @@ jobs:
 
       - name: Build and upload Docker image for data-eng-pipeline
         if: steps.prerun.outputs.result != 'skip'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: true
           tags: ${{ env.IMAGE_REGISTRY }}:${{ env.IMAGE_TAG }}-data-eng-pipeline
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Update build session with image tag for data-eng-pipeline
         id: ci-set-build-output-data-eng-pipeline
@@ -106,6 +112,8 @@ jobs:
           context: ./hooli_basics
           push: true
           tags: ${{ env.IMAGE_REGISTRY }}:${{ env.IMAGE_TAG }}-basics
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Update build session with image tag for basics
         id: ci-set-build-output-basics
@@ -138,6 +146,8 @@ jobs:
           context: ./hooli_snowflake_insights
           push: true
           tags: ${{ env.IMAGE_REGISTRY }}:${{ env.IMAGE_TAG }}-snowflake-insights
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Update build session with image tag for snowflake insights
         id: ci-set-build-output-snowflake-insights
@@ -154,6 +164,8 @@ jobs:
           context: ./hooli-demo-assets
           push: true
           tags: ${{ env.IMAGE_REGISTRY }}:${{ env.IMAGE_TAG }}-demo-assets
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Update build session with image tag for demo_assets
         id: ci-set-build-output-demo-assets
@@ -170,6 +182,8 @@ jobs:
           context: ./hooli_data_eng/utils/example_container
           push: true
           tags: ${{ env.IMAGE_REGISTRY }}:latest-pipes-example
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       # Deploy
       - name: Deploy to Dagster Cloud

--- a/.github/workflows/deploy-dagster-cloud.yml
+++ b/.github/workflows/deploy-dagster-cloud.yml
@@ -108,7 +108,7 @@ jobs:
       # Build 'basics' code location
       - name: Build and upload Docker image for basics
         if: steps.prerun.outputs.result != 'skip'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: ./hooli_basics
           push: true
@@ -126,7 +126,7 @@ jobs:
       # Build 'batch enrichment' code location
       - name: Build and upload Docker image for batch enrichment
         if: steps.prerun.outputs.result != 'skip'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: ./hooli_batch_enrichment
           push: true
@@ -142,7 +142,7 @@ jobs:
       # Build 'snowflake_insights' code location
       - name: Build and upload Docker image for snowflake insights
         if: steps.prerun.outputs.result != 'skip'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: ./hooli_snowflake_insights
           push: true
@@ -160,7 +160,7 @@ jobs:
       # Build 'demo_assets' code location
       - name: Build and upload Docker image for demo_assets
         if: steps.prerun.outputs.result != 'skip'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: ./hooli-demo-assets
           push: true
@@ -178,7 +178,7 @@ jobs:
       # Build pipes example container
       - name: Build and upload Docker image for pipes example
         if: steps.prerun.outputs.result != 'skip'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: ./hooli_data_eng/utils/example_container
           push: true

--- a/.github/workflows/deploy-dagster-cloud.yml
+++ b/.github/workflows/deploy-dagster-cloud.yml
@@ -68,7 +68,8 @@ jobs:
       - name: Login to ECR
         if: ${{ steps.prerun.outputs.result != 'skip' }}
         uses: aws-actions/amazon-ecr-login@v2
-        with: mask-password: 'true'
+        with:
+          mask-password: 'true'
 
       - name: Set Branch Deployment Environment Variable for PR
         if: steps.prerun.outputs.result != 'skip' && github.event_name == 'pull_request'


### PR DESCRIPTION
Pre, with 2 warnings:

<img width="878" alt="image" src="https://github.com/dagster-io/hooli-data-eng-pipelines/assets/12430096/47f2dab7-d3dd-472f-b4fc-26a66712ea64">

Post, with 1 warning: 🎉 

<img width="784" alt="image" src="https://github.com/dagster-io/hooli-data-eng-pipelines/assets/12430096/ef55c777-218f-4aef-bbd0-05c7b14df8c5">


I also added the docker-buidx step that is present in [our example](https://github.com/dagster-io/dagster-cloud-hybrid-quickstart/blob/main/.github/workflows/dagster-cloud-deploy.yml), though it doesn't seem to speed anything up so I'm not sure what it's purpose is.
