### PR TITLE
Add links to source code

### DIFF
--- a/.github/workflows/deploy-dagster-cloud.yml
+++ b/.github/workflows/deploy-dagster-cloud.yml
@@ -85,7 +85,7 @@ jobs:
           pip install pip --upgrade;
           pip install dagster-dbt dagster-cloud dbt-core dbt-duckdb dbt-snowflake --upgrade --upgrade-strategy eager;
           make deps
-          dagster-dbt project prepare-for-deployment --file hooli_data_eng/project.py
+          dagster-dbt project prepare-and-package --file hooli_data_eng/project.py
           dagster-cloud ci dagster-dbt project manage-state --file hooli_data_eng/project.py --source-deployment data-eng-prod
 
       - name: Build and upload Docker image for data-eng-pipeline

--- a/hooli-demo-assets/hooli_demo_assets/definitions.py
+++ b/hooli-demo-assets/hooli_demo_assets/definitions.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from dagster import (
    Definitions,  
 )
@@ -12,7 +14,8 @@ from hooli_demo_assets.schedules import daily_sling_assets
 
 defs = Definitions(
    assets=link_to_git_if_cloud(
-       with_source_code_references([my_sling_assets])
+       with_source_code_references([my_sling_assets]),
+       repository_root_absolute_path=Path(__file__).parent.parent.parent,
    ),
    schedules=[daily_sling_assets],
    jobs=[daily_sling_job],

--- a/hooli-demo-assets/hooli_demo_assets/definitions.py
+++ b/hooli-demo-assets/hooli_demo_assets/definitions.py
@@ -19,7 +19,7 @@ defs = Definitions(
        with_source_code_references([my_sling_assets]),
        file_path_mapping=AnchorBasedFilePathMapping(
             local_file_anchor=Path(__file__),
-            file_anchor_path_in_repository="hooli-data-eng-pipelines/hooli-demo-assets/hooli_demo_assets/definitions.py",
+            file_anchor_path_in_repository="hooli-demo-assets/hooli_demo_assets/definitions.py",
         ),
    ),
    schedules=[daily_sling_assets],

--- a/hooli-demo-assets/hooli_demo_assets/definitions.py
+++ b/hooli-demo-assets/hooli_demo_assets/definitions.py
@@ -15,7 +15,7 @@ from hooli_demo_assets.schedules import daily_sling_assets
 defs = Definitions(
    assets=link_to_git_if_cloud(
        with_source_code_references([my_sling_assets]),
-       repository_root_absolute_path=Path(__file__).parent.parent.parent,
+       repository_root_absolute_path=Path(__file__).parent.parent,
    ),
    schedules=[daily_sling_assets],
    jobs=[daily_sling_job],

--- a/hooli-demo-assets/hooli_demo_assets/definitions.py
+++ b/hooli-demo-assets/hooli_demo_assets/definitions.py
@@ -1,10 +1,12 @@
 from pathlib import Path
 
 from dagster import (
+   AnchorBasedFilePathMapping,
    Definitions,  
+   with_source_code_references,
 )
 from dagster._core.definitions.metadata import with_source_code_references
-from dagster_cloud.metadata.source_code import link_to_git_if_cloud
+from dagster_cloud.metadata.source_code import link_code_references_to_git_if_cloud
 
 from hooli_demo_assets.assets.sling import my_sling_assets
 from hooli_demo_assets.jobs import daily_sling_job
@@ -13,9 +15,12 @@ from hooli_demo_assets.schedules import daily_sling_assets
 
 
 defs = Definitions(
-   assets=link_to_git_if_cloud(
+   assets=link_code_references_to_git_if_cloud(
        with_source_code_references([my_sling_assets]),
-       repository_root_absolute_path=Path(__file__).parent.parent,
+       file_path_mapping=AnchorBasedFilePathMapping(
+            local_file_anchor=Path(__file__),
+            file_anchor_path_in_repository="hooli-data-eng-pipelines/hooli-demo-assets/hooli_demo_assets/definitions.py",
+        ),
    ),
    schedules=[daily_sling_assets],
    jobs=[daily_sling_job],

--- a/hooli-demo-assets/hooli_demo_assets/definitions.py
+++ b/hooli-demo-assets/hooli_demo_assets/definitions.py
@@ -2,6 +2,7 @@ from dagster import (
    Definitions,  
 )
 from dagster._core.definitions.metadata import with_source_code_references
+from dagster_cloud.metadata.source_code import link_to_git_if_cloud
 
 from hooli_demo_assets.assets.sling import my_sling_assets
 from hooli_demo_assets.jobs import daily_sling_job
@@ -10,7 +11,9 @@ from hooli_demo_assets.schedules import daily_sling_assets
 
 
 defs = Definitions(
-   assets=with_source_code_references([my_sling_assets]),
+   assets=link_to_git_if_cloud(
+       with_source_code_references([my_sling_assets])
+   ),
    schedules=[daily_sling_assets],
    jobs=[daily_sling_job],
    resources={

--- a/hooli-demo-assets/hooli_demo_assets/definitions.py
+++ b/hooli-demo-assets/hooli_demo_assets/definitions.py
@@ -1,6 +1,7 @@
 from dagster import (
    Definitions,  
 )
+from dagster._core.definitions.metadata import with_source_code_references
 
 from hooli_demo_assets.assets.sling import my_sling_assets
 from hooli_demo_assets.jobs import daily_sling_job
@@ -9,7 +10,7 @@ from hooli_demo_assets.schedules import daily_sling_assets
 
 
 defs = Definitions(
-   assets=[my_sling_assets],
+   assets=with_source_code_references([my_sling_assets]),
    schedules=[daily_sling_assets],
    jobs=[daily_sling_job],
    resources={

--- a/hooli-demo-assets/hooli_demo_assets/resources/__init__.py
+++ b/hooli-demo-assets/hooli_demo_assets/resources/__init__.py
@@ -68,7 +68,7 @@ def create_sling_resource(env: str):
            type="duckdb",
            instance=f"{DUCKDB_PATH}",
            database="example",
-           schema="RAW_DATA",
+           schema="raw_data",
        ))
    elif env == 'BRANCH':
        connections.append(SlingConnectionResource(

--- a/hooli_basics/definitions.py
+++ b/hooli_basics/definitions.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from dagster import asset, asset_check, AssetCheckResult, Definitions
 from dagster._core.definitions.metadata import with_source_code_references
 from dagster_cloud.metadata.source_code import link_to_git_if_cloud
@@ -31,8 +33,9 @@ def continent_stats(country_stats: DataFrame, change_model: Regression) -> DataF
 
 defs = Definitions(
     assets=link_to_git_if_cloud(
-        with_source_code_references([country_stats, continent_stats, change_model])
-        ), 
+        with_source_code_references([country_stats, continent_stats, change_model]),
+        repository_root_absolute_path=Path(__file__).parent.parent,
+    ), 
     asset_checks=[check_country_stats]
 )
 

--- a/hooli_basics/definitions.py
+++ b/hooli_basics/definitions.py
@@ -1,4 +1,5 @@
 from dagster import asset, asset_check, AssetCheckResult, Definitions
+from dagster._core.definitions.metadata import with_source_code_references
 from pandas import DataFrame, read_html, get_dummies, to_numeric
 from sklearn.linear_model import LinearRegression as Regression
 
@@ -28,7 +29,7 @@ def continent_stats(country_stats: DataFrame, change_model: Regression) -> DataF
     return result
 
 defs = Definitions(
-    assets=[country_stats, continent_stats, change_model], 
+    assets=with_source_code_references([country_stats, continent_stats, change_model]), 
     asset_checks=[check_country_stats]
 )
 

--- a/hooli_basics/definitions.py
+++ b/hooli_basics/definitions.py
@@ -1,8 +1,14 @@
 from pathlib import Path
 
-from dagster import asset, asset_check, AssetCheckResult, Definitions
-from dagster._core.definitions.metadata import with_source_code_references
-from dagster_cloud.metadata.source_code import link_to_git_if_cloud
+from dagster import (
+    AnchorBasedFilePathMapping,
+    asset,
+    asset_check,
+    AssetCheckResult,
+    Definitions,
+    with_source_code_references,
+)
+from dagster_cloud.metadata.source_code import link_code_references_to_git_if_cloud
 from pandas import DataFrame, read_html, get_dummies, to_numeric
 from sklearn.linear_model import LinearRegression as Regression
 
@@ -32,9 +38,12 @@ def continent_stats(country_stats: DataFrame, change_model: Regression) -> DataF
     return result
 
 defs = Definitions(
-    assets=link_to_git_if_cloud(
+    assets=link_code_references_to_git_if_cloud(
         with_source_code_references([country_stats, continent_stats, change_model]),
-        repository_root_absolute_path=Path(__file__).parent,
+        file_path_mapping=AnchorBasedFilePathMapping(
+            local_file_anchor=Path(__file__),
+            file_anchor_path_in_repository="hooli-data-eng-pipelines/hooli_basics/definitions.py",
+        ),
     ), 
     asset_checks=[check_country_stats]
 )

--- a/hooli_basics/definitions.py
+++ b/hooli_basics/definitions.py
@@ -42,7 +42,7 @@ defs = Definitions(
         with_source_code_references([country_stats, continent_stats, change_model]),
         file_path_mapping=AnchorBasedFilePathMapping(
             local_file_anchor=Path(__file__),
-            file_anchor_path_in_repository="hooli-data-eng-pipelines/hooli_basics/definitions.py",
+            file_anchor_path_in_repository="hooli_basics/definitions.py",
         ),
     ), 
     asset_checks=[check_country_stats]

--- a/hooli_basics/definitions.py
+++ b/hooli_basics/definitions.py
@@ -1,5 +1,6 @@
 from dagster import asset, asset_check, AssetCheckResult, Definitions
 from dagster._core.definitions.metadata import with_source_code_references
+from dagster_cloud.metadata.source_code import link_to_git_if_cloud
 from pandas import DataFrame, read_html, get_dummies, to_numeric
 from sklearn.linear_model import LinearRegression as Regression
 
@@ -29,7 +30,9 @@ def continent_stats(country_stats: DataFrame, change_model: Regression) -> DataF
     return result
 
 defs = Definitions(
-    assets=with_source_code_references([country_stats, continent_stats, change_model]), 
+    assets=link_to_git_if_cloud(
+        with_source_code_references([country_stats, continent_stats, change_model])
+        ), 
     asset_checks=[check_country_stats]
 )
 

--- a/hooli_basics/definitions.py
+++ b/hooli_basics/definitions.py
@@ -34,7 +34,7 @@ def continent_stats(country_stats: DataFrame, change_model: Regression) -> DataF
 defs = Definitions(
     assets=link_to_git_if_cloud(
         with_source_code_references([country_stats, continent_stats, change_model]),
-        repository_root_absolute_path=Path(__file__).parent.parent,
+        repository_root_absolute_path=Path(__file__).parent,
     ), 
     asset_checks=[check_country_stats]
 )

--- a/hooli_batch_enrichment/dagster_batch_enrichment/definitions.py
+++ b/hooli_batch_enrichment/dagster_batch_enrichment/definitions.py
@@ -33,7 +33,7 @@ defs = Definitions(
         with_source_code_references([raw_data, enriched_data]),
         file_path_mapping=AnchorBasedFilePathMapping(
             local_file_anchor=Path(__file__),
-            file_anchor_path_in_repository="hooli-data-eng-pipelines/hooli_batch_enrichment/dagster_batch_enrichment/definitions.py",
+            file_anchor_path_in_repository="hooli_batch_enrichment/dagster_batch_enrichment/definitions.py",
         ),
     ),
     schedules=[run_assets_30min],

--- a/hooli_batch_enrichment/dagster_batch_enrichment/definitions.py
+++ b/hooli_batch_enrichment/dagster_batch_enrichment/definitions.py
@@ -1,11 +1,17 @@
 from pathlib import Path
 
-from dagster import Definitions, define_asset_job, ScheduleDefinition, AssetSelection
-from dagster._core.definitions.metadata import with_source_code_references
+from dagster import (
+    AnchorBasedFilePathMapping,
+    AssetSelection,
+    define_asset_job,
+    Definitions,
+    ScheduleDefinition,
+    with_source_code_references,
+)
 from dagster_batch_enrichment.api import EnrichmentAPI
 from dagster_batch_enrichment.warehouse import MyWarehouse
 from dagster_batch_enrichment.assets import raw_data, enriched_data
-from dagster_cloud.metadata.source_code import link_to_git_if_cloud
+from dagster_cloud.metadata.source_code import link_code_references_to_git_if_cloud
 
 
 # define a job and schedule to run the pipeline
@@ -23,9 +29,12 @@ run_assets_30min = ScheduleDefinition(
 )
 
 defs = Definitions(
-    assets=link_to_git_if_cloud(
+    assets=link_code_references_to_git_if_cloud(
         with_source_code_references([raw_data, enriched_data]),
-        repository_root_absolute_path=Path(__file__).parent.parent,
+        file_path_mapping=AnchorBasedFilePathMapping(
+            local_file_anchor=Path(__file__),
+            file_anchor_path_in_repository="hooli-data-eng-pipelines/hooli_batch_enrichment/dagster_batch_enrichment/definitions.py",
+        ),
     ),
     schedules=[run_assets_30min],
     jobs=[run_assets_job],

--- a/hooli_batch_enrichment/dagster_batch_enrichment/definitions.py
+++ b/hooli_batch_enrichment/dagster_batch_enrichment/definitions.py
@@ -3,6 +3,7 @@ from dagster._core.definitions.metadata import with_source_code_references
 from dagster_batch_enrichment.api import EnrichmentAPI
 from dagster_batch_enrichment.warehouse import MyWarehouse
 from dagster_batch_enrichment.assets import raw_data, enriched_data
+from dagster_cloud.metadata.source_code import link_to_git_if_cloud
 
 
 # define a job and schedule to run the pipeline
@@ -20,7 +21,9 @@ run_assets_30min = ScheduleDefinition(
 )
 
 defs = Definitions(
-    assets=with_source_code_references([raw_data, enriched_data]),
+    assets=link_to_git_if_cloud(
+        with_source_code_references([raw_data, enriched_data])
+    ),
     schedules=[run_assets_30min],
     jobs=[run_assets_job],
     resources={

--- a/hooli_batch_enrichment/dagster_batch_enrichment/definitions.py
+++ b/hooli_batch_enrichment/dagster_batch_enrichment/definitions.py
@@ -25,7 +25,7 @@ run_assets_30min = ScheduleDefinition(
 defs = Definitions(
     assets=link_to_git_if_cloud(
         with_source_code_references([raw_data, enriched_data]),
-        repository_root_absolute_path=Path(__file__).parent.parent.parent,
+        repository_root_absolute_path=Path(__file__).parent.parent,
     ),
     schedules=[run_assets_30min],
     jobs=[run_assets_job],

--- a/hooli_batch_enrichment/dagster_batch_enrichment/definitions.py
+++ b/hooli_batch_enrichment/dagster_batch_enrichment/definitions.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from dagster import Definitions, define_asset_job, ScheduleDefinition, AssetSelection
 from dagster._core.definitions.metadata import with_source_code_references
 from dagster_batch_enrichment.api import EnrichmentAPI
@@ -22,7 +24,8 @@ run_assets_30min = ScheduleDefinition(
 
 defs = Definitions(
     assets=link_to_git_if_cloud(
-        with_source_code_references([raw_data, enriched_data])
+        with_source_code_references([raw_data, enriched_data]),
+        repository_root_absolute_path=Path(__file__).parent.parent.parent,
     ),
     schedules=[run_assets_30min],
     jobs=[run_assets_job],

--- a/hooli_batch_enrichment/dagster_batch_enrichment/definitions.py
+++ b/hooli_batch_enrichment/dagster_batch_enrichment/definitions.py
@@ -1,4 +1,5 @@
 from dagster import Definitions, define_asset_job, ScheduleDefinition, AssetSelection
+from dagster._core.definitions.metadata import with_source_code_references
 from dagster_batch_enrichment.api import EnrichmentAPI
 from dagster_batch_enrichment.warehouse import MyWarehouse
 from dagster_batch_enrichment.assets import raw_data, enriched_data
@@ -19,7 +20,7 @@ run_assets_30min = ScheduleDefinition(
 )
 
 defs = Definitions(
-    assets=[raw_data, enriched_data],
+    assets=with_source_code_references([raw_data, enriched_data]),
     schedules=[run_assets_30min],
     jobs=[run_assets_job],
     resources={

--- a/hooli_data_eng/assets/dbt_assets.py
+++ b/hooli_data_eng/assets/dbt_assets.py
@@ -133,10 +133,12 @@ def _process_partitioned_dbt_assets(context: OpExecutionContext, dbt: DbtCliReso
 
 @dbt_assets(
     manifest=DBT_MANIFEST,
+    project=dbt_project,
     select="orders_cleaned users_cleaned orders_augmented",
     partitions_def=daily_partitions,
     dagster_dbt_translator=CustomDagsterDbtTranslator(
-        settings=DagsterDbtTranslatorSettings(enable_asset_checks=True)
+        settings=DagsterDbtTranslatorSettings(enable_asset_checks=True,
+                                              enable_code_references=True,)
     ),
     backfill_policy=BackfillPolicy.single_run(),
 )
@@ -146,10 +148,12 @@ def daily_dbt_assets(context: OpExecutionContext, dbt2: DbtCliResource):
 
 @dbt_assets(
     manifest=DBT_MANIFEST,
+    project=dbt_project,
     select="weekly_order_summary order_stats",
     partitions_def=weekly_partitions,
     dagster_dbt_translator=CustomDagsterDbtTranslator(
-        DagsterDbtTranslatorSettings(enable_asset_checks=True)
+        DagsterDbtTranslatorSettings(enable_asset_checks=True,
+                                     enable_code_references=True,)
     ),
     backfill_policy=BackfillPolicy.single_run(),
 )
@@ -164,9 +168,11 @@ weekly_freshness_check_sensor=build_sensor_for_freshness_checks(
 
 @dbt_assets(
     manifest=DBT_MANIFEST,
+    project=dbt_project,
     select="company_perf sku_stats company_stats locations_cleaned",
     dagster_dbt_translator=CustomDagsterDbtTranslatorForViews(
-        DagsterDbtTranslatorSettings(enable_asset_checks=True)
+        DagsterDbtTranslatorSettings(enable_asset_checks=True,
+                                     enable_code_references=True,)
     ),
 )
 def views_dbt_assets(context: OpExecutionContext, dbt2: DbtCliResource):
@@ -203,8 +209,10 @@ def dbt_slim_ci(dbt2: DbtCliResource):
     yield from dbt2.cli(
         args=dbt_command,
         manifest=DBT_MANIFEST,
+        project=dbt_project,
         dagster_dbt_translator=CustomDagsterDbtTranslator(
-            DagsterDbtTranslatorSettings(enable_asset_checks=True)
+            DagsterDbtTranslatorSettings(enable_asset_checks=True,
+                                         enable_code_references=True,)
         ),
     ).stream().fetch_row_counts().fetch_column_metadata()
 

--- a/hooli_data_eng/definitions.py
+++ b/hooli_data_eng/definitions.py
@@ -6,6 +6,8 @@ from dagster import (
     build_column_schema_change_checks,
     multiprocess_executor,
 )
+from dagster._core.definitions.metadata import with_source_code_references
+from dagster_cloud.metadata.source_code import link_to_git_if_cloud
 
 from hooli_data_eng.assets import forecasting, raw_data, marketing, dbt_assets
 from hooli_data_eng.assets.dbt_assets import dbt_slim_ci_job
@@ -65,7 +67,9 @@ defs = Definitions(
     executor=multiprocess_executor.configured(
         {"max_concurrent": 3}
     ),  
-    assets=[*dbt_assets, *raw_data_assets, *forecasting_assets, *marketing_assets], #
+    assets=link_to_git_if_cloud( ###TODO add asset_defs per docs—ask Ben)
+        with_source_code_references([*dbt_assets, *raw_data_assets, *forecasting_assets, *marketing_assets])
+    ),
     asset_checks=[*raw_data_schema_checks, *dbt_asset_checks, check_users, check_avg_orders, *min_order_freshness_check, *avg_orders_freshness_check, *weekly_freshness_check],
     resources=resource_def[get_env()],
     schedules=[analytics_schedule, avg_orders_freshness_check_schedule],

--- a/hooli_data_eng/definitions.py
+++ b/hooli_data_eng/definitions.py
@@ -67,7 +67,7 @@ defs = Definitions(
     executor=multiprocess_executor.configured(
         {"max_concurrent": 3}
     ),  
-    assets=link_to_git_if_cloud( ###TODO add asset_defs per docs—ask Ben)
+    assets=link_to_git_if_cloud(
         with_source_code_references([*dbt_assets, *raw_data_assets, *forecasting_assets, *marketing_assets])
     ),
     asset_checks=[*raw_data_schema_checks, *dbt_asset_checks, check_users, check_avg_orders, *min_order_freshness_check, *avg_orders_freshness_check, *weekly_freshness_check],

--- a/hooli_data_eng/definitions.py
+++ b/hooli_data_eng/definitions.py
@@ -6,9 +6,9 @@ from dagster import (
     load_assets_from_package_module,
     build_column_schema_change_checks,
     multiprocess_executor,
+    with_source_code_references,
 )
-from dagster._core.definitions.metadata import with_source_code_references
-from dagster_cloud.metadata.source_code import link_to_git_if_cloud
+from dagster_cloud.metadata.source_code import link_code_references_to_git_if_cloud
 
 from hooli_data_eng.assets import forecasting, raw_data, marketing, dbt_assets
 from hooli_data_eng.assets.dbt_assets import dbt_slim_ci_job
@@ -68,9 +68,8 @@ defs = Definitions(
     executor=multiprocess_executor.configured(
         {"max_concurrent": 3}
     ),  
-    assets=link_to_git_if_cloud(
+    assets=link_code_references_to_git_if_cloud(
         with_source_code_references([*dbt_assets, *raw_data_assets, *forecasting_assets, *marketing_assets]),
-        repository_root_absolute_path=Path(__file__).parent,
     ),
     asset_checks=[*raw_data_schema_checks, *dbt_asset_checks, check_users, check_avg_orders, *min_order_freshness_check, *avg_orders_freshness_check, *weekly_freshness_check],
     resources=resource_def[get_env()],

--- a/hooli_data_eng/definitions.py
+++ b/hooli_data_eng/definitions.py
@@ -17,7 +17,7 @@ from hooli_data_eng.assets.raw_data import check_users, raw_data_schema_checks
 from hooli_data_eng.jobs import analytics_job, predict_job
 from hooli_data_eng.resources import get_env, resource_def
 from hooli_data_eng.schedules import analytics_schedule
-from hooli_data_eng.sensors import orders_sensor, my_dbt_code_version_sensor
+from hooli_data_eng.sensors import orders_sensor, dbt_code_version_sensor
 from hooli_data_eng.sensors.watch_s3 import watch_s3_sensor
 from hooli_data_eng.assets.marketing import avg_orders_freshness_check, min_order_freshness_check, min_order_freshness_check_sensor, check_avg_orders, avg_orders_freshness_check_schedule
 from hooli_data_eng.assets.dbt_assets import weekly_freshness_check, weekly_freshness_check_sensor
@@ -80,7 +80,7 @@ defs = Definitions(
        watch_s3_sensor,
 #       asset_delay_alert_sensor,
        min_order_freshness_check_sensor,
-       my_dbt_code_version_sensor,
+       dbt_code_version_sensor,
        weekly_freshness_check_sensor
     ],
     jobs=[analytics_job, predict_job, dbt_slim_ci_job],

--- a/hooli_data_eng/definitions.py
+++ b/hooli_data_eng/definitions.py
@@ -17,7 +17,7 @@ from hooli_data_eng.assets.raw_data import check_users, raw_data_schema_checks
 from hooli_data_eng.jobs import analytics_job, predict_job
 from hooli_data_eng.resources import get_env, resource_def
 from hooli_data_eng.schedules import analytics_schedule
-from hooli_data_eng.sensors import orders_sensor
+from hooli_data_eng.sensors import orders_sensor, my_dbt_code_version_sensor
 from hooli_data_eng.sensors.watch_s3 import watch_s3_sensor
 from hooli_data_eng.assets.marketing import avg_orders_freshness_check, min_order_freshness_check, min_order_freshness_check_sensor, check_avg_orders, avg_orders_freshness_check_schedule
 from hooli_data_eng.assets.dbt_assets import weekly_freshness_check, weekly_freshness_check_sensor
@@ -80,6 +80,7 @@ defs = Definitions(
        watch_s3_sensor,
 #       asset_delay_alert_sensor,
        min_order_freshness_check_sensor,
+       my_dbt_code_version_sensor,
        weekly_freshness_check_sensor
     ],
     jobs=[analytics_job, predict_job, dbt_slim_ci_job],

--- a/hooli_data_eng/definitions.py
+++ b/hooli_data_eng/definitions.py
@@ -70,7 +70,7 @@ defs = Definitions(
     ),  
     assets=link_to_git_if_cloud(
         with_source_code_references([*dbt_assets, *raw_data_assets, *forecasting_assets, *marketing_assets]),
-        repository_root_absolute_path=Path(__file__).parent.parent,
+        repository_root_absolute_path=Path(__file__).parent,
     ),
     asset_checks=[*raw_data_schema_checks, *dbt_asset_checks, check_users, check_avg_orders, *min_order_freshness_check, *avg_orders_freshness_check, *weekly_freshness_check],
     resources=resource_def[get_env()],

--- a/hooli_data_eng/definitions.py
+++ b/hooli_data_eng/definitions.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 
 from dagster import (
     Definitions,
@@ -68,7 +69,8 @@ defs = Definitions(
         {"max_concurrent": 3}
     ),  
     assets=link_to_git_if_cloud(
-        with_source_code_references([*dbt_assets, *raw_data_assets, *forecasting_assets, *marketing_assets])
+        with_source_code_references([*dbt_assets, *raw_data_assets, *forecasting_assets, *marketing_assets]),
+        repository_root_absolute_path=Path(__file__).parent.parent,
     ),
     asset_checks=[*raw_data_schema_checks, *dbt_asset_checks, check_users, check_avg_orders, *min_order_freshness_check, *avg_orders_freshness_check, *weekly_freshness_check],
     resources=resource_def[get_env()],

--- a/hooli_data_eng/sensors/__init__.py
+++ b/hooli_data_eng/sensors/__init__.py
@@ -12,7 +12,7 @@ from hooli_data_eng.jobs import predict_job
 
 
 from hooli_data_eng.assets.dbt_assets import views_dbt_assets
-from hooli_data_eng.utils import get_current_dbt_code_version
+from hooli_data_eng.utils.dbt_code_version import get_current_dbt_code_version
 
 # This sensor listens for changes to the orders_augmented asset which
 # represents a dbt model. When the table managed by dbt is updated,

--- a/hooli_data_eng/sensors/__init__.py
+++ b/hooli_data_eng/sensors/__init__.py
@@ -1,5 +1,3 @@
-import hashlib
-import json
 from dagster import (
     asset_sensor,
     sensor,
@@ -8,15 +6,13 @@ from dagster import (
     RunRequest,
     SensorEvaluationContext,
     AssetSelection,
-    SensorDefinition,
-    DagsterInstance,
 )
 from datetime import datetime
 from hooli_data_eng.jobs import predict_job
 
 
 from hooli_data_eng.assets.dbt_assets import views_dbt_assets
-from hooli_data_eng.project import dbt_project
+from hooli_data_eng.utils import get_current_dbt_code_version
 
 # This sensor listens for changes to the orders_augmented asset which
 # represents a dbt model. When the table managed by dbt is updated,
@@ -27,25 +23,13 @@ def orders_sensor(context: SensorEvaluationContext, asset_event: EventLogEntry):
     yield RunRequest(run_key=context.cursor)
 
 
-def get_current_dbt_code_version(asset_key: AssetKey) -> str:
-    with open(dbt_project.manifest_path) as f:
-        manifest = json.load(f)
-    
-    model_name = asset_key.path[-1]
-    model_sql = manifest["nodes"][f"model.dbt_project.{model_name}"]["raw_code"]
-    
-    return hashlib.sha1(model_sql.encode("utf-8")).hexdigest()
-
 
 @sensor(asset_selection=AssetSelection.assets(views_dbt_assets))
-def my_dbt_code_version_sensor(context: SensorEvaluationContext):
-    #asset_keys = [AssetKey("my_dbt_model_1"), AssetKey("my_dbt_model_2")]  # List your dbt asset keys here
+def dbt_code_version_sensor(context: SensorEvaluationContext):
     
     context.log.info(f"Checking code versions for assets: {views_dbt_assets.keys}")
-    print(f"Checking code versions for assets: {views_dbt_assets.keys}")
     assets_to_materialize = []
     for asset_key in views_dbt_assets.keys:
-        # instance = DagsterInstance.get()
         latest_materialization = context.instance.get_latest_materialization_event(asset_key)
         if latest_materialization:
             latest_code_version = latest_materialization.asset_materialization.tags.get("dagster/code_version")
@@ -60,10 +44,3 @@ def my_dbt_code_version_sensor(context: SensorEvaluationContext):
             run_key=f"code_version_update_{datetime.now()}",
             asset_selection=list(assets_to_materialize)
             )
-    # if never materialized before, materialize all
-    # currently doesn't work
-    # else:
-    #     yield RunRequest(
-    #         run_key=f"code_version_update_{datetime.now()}",
-    #         asset_selection=list(views_dbt_assets.keys) 
-    #     )

--- a/hooli_data_eng/sensors/__init__.py
+++ b/hooli_data_eng/sensors/__init__.py
@@ -1,12 +1,22 @@
+import hashlib
+import json
 from dagster import (
     asset_sensor,
+    sensor,
     AssetKey,
     EventLogEntry,
     RunRequest,
     SensorEvaluationContext,
+    AssetSelection,
+    SensorDefinition,
+    DagsterInstance,
 )
-
+from datetime import datetime
 from hooli_data_eng.jobs import predict_job
+
+
+from hooli_data_eng.assets.dbt_assets import views_dbt_assets
+from hooli_data_eng.project import dbt_project
 
 # This sensor listens for changes to the orders_augmented asset which
 # represents a dbt model. When the table managed by dbt is updated,
@@ -15,3 +25,45 @@ from hooli_data_eng.jobs import predict_job
 @asset_sensor(asset_key=AssetKey(["ANALYTICS", "orders_augmented"]), job=predict_job)
 def orders_sensor(context: SensorEvaluationContext, asset_event: EventLogEntry):
     yield RunRequest(run_key=context.cursor)
+
+
+def get_current_dbt_code_version(asset_key: AssetKey) -> str:
+    with open(dbt_project.manifest_path) as f:
+        manifest = json.load(f)
+    
+    model_name = asset_key.path[-1]
+    model_sql = manifest["nodes"][f"model.dbt_project.{model_name}"]["raw_code"]
+    
+    return hashlib.sha1(model_sql.encode("utf-8")).hexdigest()
+
+
+@sensor(asset_selection=AssetSelection.assets(views_dbt_assets))
+def my_dbt_code_version_sensor(context: SensorEvaluationContext):
+    #asset_keys = [AssetKey("my_dbt_model_1"), AssetKey("my_dbt_model_2")]  # List your dbt asset keys here
+    
+    context.log.info(f"Checking code versions for assets: {views_dbt_assets.keys}")
+    print(f"Checking code versions for assets: {views_dbt_assets.keys}")
+    assets_to_materialize = []
+    for asset_key in views_dbt_assets.keys:
+        # instance = DagsterInstance.get()
+        latest_materialization = context.instance.get_latest_materialization_event(asset_key)
+        if latest_materialization:
+            latest_code_version = latest_materialization.asset_materialization.tags.get("dagster/code_version")
+            context.log.info(f"Latest code version for {asset_key}: {latest_code_version}")
+            current_code_version = get_current_dbt_code_version(asset_key)  # Implement this function to get the current code version
+            context.log.info(f"Current code version for {asset_key}: {current_code_version}")
+            if latest_code_version != current_code_version:
+                assets_to_materialize.append(asset_key)
+    context.log.info(f"Assets to materialize: {assets_to_materialize}")
+    if assets_to_materialize:
+        yield RunRequest(
+            run_key=f"code_version_update_{datetime.now()}",
+            asset_selection=list(assets_to_materialize)
+            )
+    # if never materialized before, materialize all
+    # currently doesn't work
+    # else:
+    #     yield RunRequest(
+    #         run_key=f"code_version_update_{datetime.now()}",
+    #         asset_selection=list(views_dbt_assets.keys) 
+    #     )

--- a/hooli_data_eng/utils/dbt_code_version.py
+++ b/hooli_data_eng/utils/dbt_code_version.py
@@ -1,0 +1,13 @@
+import hashlib
+import json
+from dagster import AssetKey
+from dagster_dbt import dbt_project
+
+def get_current_dbt_code_version(asset_key: AssetKey) -> str:
+    with open(dbt_project.manifest_path) as f:
+        manifest = json.load(f)
+    
+    model_name = asset_key.path[-1]
+    model_sql = manifest["nodes"][f"model.dbt_project.{model_name}"]["raw_code"]
+    
+    return hashlib.sha1(model_sql.encode("utf-8")).hexdigest()

--- a/hooli_data_eng/utils/dbt_code_version.py
+++ b/hooli_data_eng/utils/dbt_code_version.py
@@ -1,7 +1,7 @@
 import hashlib
 import json
 from dagster import AssetKey
-from dagster_dbt import dbt_project
+from hooli_data_eng.project import dbt_project
 
 def get_current_dbt_code_version(asset_key: AssetKey) -> str:
     with open(dbt_project.manifest_path) as f:

--- a/hooli_snowflake_insights/definitions.py
+++ b/hooli_snowflake_insights/definitions.py
@@ -48,7 +48,7 @@ snowflake_insights_definitions = create_snowflake_insights_asset_and_schedule(
 defs = Definitions(
     assets=link_to_git_if_cloud(
         with_source_code_references([*snowflake_insights_definitions.assets,]),
-        repository_root_absolute_path=Path(__file__).parent.parent,
+        repository_root_absolute_path=Path(__file__).parent,
     ),
     schedules=[snowflake_insights_definitions.schedule,],
     resources=resource_def[get_env()],

--- a/hooli_snowflake_insights/definitions.py
+++ b/hooli_snowflake_insights/definitions.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 from dagster import Definitions, EnvVar, ResourceDefinition
 from dagster._core.definitions.metadata import with_source_code_references
@@ -46,7 +47,8 @@ snowflake_insights_definitions = create_snowflake_insights_asset_and_schedule(
 
 defs = Definitions(
     assets=link_to_git_if_cloud(
-        with_source_code_references([*snowflake_insights_definitions.assets,])
+        with_source_code_references([*snowflake_insights_definitions.assets,]),
+        repository_root_absolute_path=Path(__file__).parent.parent,
     ),
     schedules=[snowflake_insights_definitions.schedule,],
     resources=resource_def[get_env()],

--- a/hooli_snowflake_insights/definitions.py
+++ b/hooli_snowflake_insights/definitions.py
@@ -55,7 +55,7 @@ defs = Definitions(
         with_source_code_references([*snowflake_insights_definitions.assets,]),
         file_path_mapping=AnchorBasedFilePathMapping(
             local_file_anchor=Path(__file__),
-            file_anchor_path_in_repository="hooli-data-eng-pipelines/hooli_snowflake_insights/definitions.py",
+            file_anchor_path_in_repository="hooli_snowflake_insights/definitions.py",
         ),
     ),
     schedules=[snowflake_insights_definitions.schedule,],

--- a/hooli_snowflake_insights/definitions.py
+++ b/hooli_snowflake_insights/definitions.py
@@ -5,6 +5,7 @@ from dagster._core.definitions.metadata import with_source_code_references
 from dagster_cloud.dagster_insights import (
     create_snowflake_insights_asset_and_schedule,
 )
+from dagster_cloud.metadata.source_code import link_to_git_if_cloud
 from dagster_snowflake import SnowflakeResource
 
 # Used to derive environment (LOCAL, BRANCH, PROD)
@@ -44,7 +45,9 @@ snowflake_insights_definitions = create_snowflake_insights_asset_and_schedule(
 )
 
 defs = Definitions(
-    assets=with_source_code_references([*snowflake_insights_definitions.assets,]),
+    assets=link_to_git_if_cloud(
+        with_source_code_references([*snowflake_insights_definitions.assets,])
+    ),
     schedules=[snowflake_insights_definitions.schedule,],
     resources=resource_def[get_env()],
 )

--- a/hooli_snowflake_insights/definitions.py
+++ b/hooli_snowflake_insights/definitions.py
@@ -1,6 +1,7 @@
 import os
 
 from dagster import Definitions, EnvVar, ResourceDefinition
+from dagster._core.definitions.metadata import with_source_code_references
 from dagster_cloud.dagster_insights import (
     create_snowflake_insights_asset_and_schedule,
 )
@@ -43,7 +44,7 @@ snowflake_insights_definitions = create_snowflake_insights_asset_and_schedule(
 )
 
 defs = Definitions(
-    assets=[*snowflake_insights_definitions.assets,],
+    assets=with_source_code_references([*snowflake_insights_definitions.assets,]),
     schedules=[snowflake_insights_definitions.schedule,],
     resources=resource_def[get_env()],
 )

--- a/workspace.yaml
+++ b/workspace.yaml
@@ -5,3 +5,7 @@ load_from:
 #  - python_module:
 #      module_name: hooli_demo_assets
 #      working_directory: hooli-demo-assets/
+#  - python_file: hooli_basics/definitions.py
+#  - python_module:
+#      module_name: dagster_batch_enrichment
+#      working_directory: hooli_batch_enrichment/


### PR DESCRIPTION
This change allows you to link back to an asset's source code from Dagster's UI.

This [utility](https://benpankow-code-references-git.dagster.dagster-docs.io/guides/dagster/code-references#in-dagster-plus) will automatically detect if your code is running in a Dagster Cloud environment and convert local file code references to source control links, pointing at the commit hash of the code running in the current deployment.