### PR TITLE
Add a sensor for dbt views

### DIFF
--- a/hooli_data_eng/definitions.py
+++ b/hooli_data_eng/definitions.py
@@ -14,7 +14,7 @@ from hooli_data_eng.assets.raw_data import check_users, raw_data_schema_checks
 from hooli_data_eng.jobs import analytics_job, predict_job
 from hooli_data_eng.resources import get_env, resource_def
 from hooli_data_eng.schedules import analytics_schedule
-from hooli_data_eng.sensors import orders_sensor
+from hooli_data_eng.sensors import orders_sensor, my_dbt_code_version_sensor
 from hooli_data_eng.sensors.watch_s3 import watch_s3_sensor
 from hooli_data_eng.assets.marketing import avg_orders_freshness_check, min_order_freshness_check, min_order_freshness_check_sensor, check_avg_orders, avg_orders_freshness_check_schedule
 from hooli_data_eng.assets.dbt_assets import weekly_freshness_check, weekly_freshness_check_sensor
@@ -74,6 +74,7 @@ defs = Definitions(
        watch_s3_sensor,
 #       asset_delay_alert_sensor,
        min_order_freshness_check_sensor,
+       my_dbt_code_version_sensor,
        weekly_freshness_check_sensor
     ],
     jobs=[analytics_job, predict_job, dbt_slim_ci_job],

--- a/hooli_data_eng/definitions.py
+++ b/hooli_data_eng/definitions.py
@@ -14,7 +14,7 @@ from hooli_data_eng.assets.raw_data import check_users, raw_data_schema_checks
 from hooli_data_eng.jobs import analytics_job, predict_job
 from hooli_data_eng.resources import get_env, resource_def
 from hooli_data_eng.schedules import analytics_schedule
-from hooli_data_eng.sensors import orders_sensor, my_dbt_code_version_sensor
+from hooli_data_eng.sensors import orders_sensor, dbt_code_version_sensor
 from hooli_data_eng.sensors.watch_s3 import watch_s3_sensor
 from hooli_data_eng.assets.marketing import avg_orders_freshness_check, min_order_freshness_check, min_order_freshness_check_sensor, check_avg_orders, avg_orders_freshness_check_schedule
 from hooli_data_eng.assets.dbt_assets import weekly_freshness_check, weekly_freshness_check_sensor
@@ -74,7 +74,7 @@ defs = Definitions(
        watch_s3_sensor,
 #       asset_delay_alert_sensor,
        min_order_freshness_check_sensor,
-       my_dbt_code_version_sensor,
+       dbt_code_version_sensor,
        weekly_freshness_check_sensor
     ],
     jobs=[analytics_job, predict_job, dbt_slim_ci_job],

--- a/hooli_data_eng/sensors/__init__.py
+++ b/hooli_data_eng/sensors/__init__.py
@@ -12,7 +12,7 @@ from hooli_data_eng.jobs import predict_job
 
 
 from hooli_data_eng.assets.dbt_assets import views_dbt_assets
-from hooli_data_eng.utils import get_current_dbt_code_version
+from hooli_data_eng.utils.dbt_code_version import get_current_dbt_code_version
 
 # This sensor listens for changes to the orders_augmented asset which
 # represents a dbt model. When the table managed by dbt is updated,

--- a/hooli_data_eng/sensors/__init__.py
+++ b/hooli_data_eng/sensors/__init__.py
@@ -1,5 +1,3 @@
-import hashlib
-import json
 from dagster import (
     asset_sensor,
     sensor,
@@ -8,15 +6,13 @@ from dagster import (
     RunRequest,
     SensorEvaluationContext,
     AssetSelection,
-    SensorDefinition,
-    DagsterInstance,
 )
 from datetime import datetime
 from hooli_data_eng.jobs import predict_job
 
 
 from hooli_data_eng.assets.dbt_assets import views_dbt_assets
-from hooli_data_eng.project import dbt_project
+from hooli_data_eng.utils import get_current_dbt_code_version
 
 # This sensor listens for changes to the orders_augmented asset which
 # represents a dbt model. When the table managed by dbt is updated,
@@ -27,25 +23,13 @@ def orders_sensor(context: SensorEvaluationContext, asset_event: EventLogEntry):
     yield RunRequest(run_key=context.cursor)
 
 
-def get_current_dbt_code_version(asset_key: AssetKey) -> str:
-    with open(dbt_project.manifest_path) as f:
-        manifest = json.load(f)
-    
-    model_name = asset_key.path[-1]
-    model_sql = manifest["nodes"][f"model.dbt_project.{model_name}"]["raw_code"]
-    
-    return hashlib.sha1(model_sql.encode("utf-8")).hexdigest()
-
 
 @sensor(asset_selection=AssetSelection.assets(views_dbt_assets))
-def my_dbt_code_version_sensor(context: SensorEvaluationContext):
-    #asset_keys = [AssetKey("my_dbt_model_1"), AssetKey("my_dbt_model_2")]  # List your dbt asset keys here
+def dbt_code_version_sensor(context: SensorEvaluationContext):
     
     context.log.info(f"Checking code versions for assets: {views_dbt_assets.keys}")
-    print(f"Checking code versions for assets: {views_dbt_assets.keys}")
     assets_to_materialize = []
     for asset_key in views_dbt_assets.keys:
-        # instance = DagsterInstance.get()
         latest_materialization = context.instance.get_latest_materialization_event(asset_key)
         if latest_materialization:
             latest_code_version = latest_materialization.asset_materialization.tags.get("dagster/code_version")
@@ -60,10 +44,3 @@ def my_dbt_code_version_sensor(context: SensorEvaluationContext):
             run_key=f"code_version_update_{datetime.now()}",
             asset_selection=list(assets_to_materialize)
             )
-    # if never materialized before, materialize all
-    # currently doesn't work
-    # else:
-    #     yield RunRequest(
-    #         run_key=f"code_version_update_{datetime.now()}",
-    #         asset_selection=list(views_dbt_assets.keys) 
-    #     )

--- a/hooli_data_eng/sensors/__init__.py
+++ b/hooli_data_eng/sensors/__init__.py
@@ -1,12 +1,22 @@
+import hashlib
+import json
 from dagster import (
     asset_sensor,
+    sensor,
     AssetKey,
     EventLogEntry,
     RunRequest,
     SensorEvaluationContext,
+    AssetSelection,
+    SensorDefinition,
+    DagsterInstance,
 )
-
+from datetime import datetime
 from hooli_data_eng.jobs import predict_job
+
+
+from hooli_data_eng.assets.dbt_assets import views_dbt_assets
+from hooli_data_eng.project import dbt_project
 
 # This sensor listens for changes to the orders_augmented asset which
 # represents a dbt model. When the table managed by dbt is updated,
@@ -15,3 +25,45 @@ from hooli_data_eng.jobs import predict_job
 @asset_sensor(asset_key=AssetKey(["ANALYTICS", "orders_augmented"]), job=predict_job)
 def orders_sensor(context: SensorEvaluationContext, asset_event: EventLogEntry):
     yield RunRequest(run_key=context.cursor)
+
+
+def get_current_dbt_code_version(asset_key: AssetKey) -> str:
+    with open(dbt_project.manifest_path) as f:
+        manifest = json.load(f)
+    
+    model_name = asset_key.path[-1]
+    model_sql = manifest["nodes"][f"model.dbt_project.{model_name}"]["raw_code"]
+    
+    return hashlib.sha1(model_sql.encode("utf-8")).hexdigest()
+
+
+@sensor(asset_selection=AssetSelection.assets(views_dbt_assets))
+def my_dbt_code_version_sensor(context: SensorEvaluationContext):
+    #asset_keys = [AssetKey("my_dbt_model_1"), AssetKey("my_dbt_model_2")]  # List your dbt asset keys here
+    
+    context.log.info(f"Checking code versions for assets: {views_dbt_assets.keys}")
+    print(f"Checking code versions for assets: {views_dbt_assets.keys}")
+    assets_to_materialize = []
+    for asset_key in views_dbt_assets.keys:
+        # instance = DagsterInstance.get()
+        latest_materialization = context.instance.get_latest_materialization_event(asset_key)
+        if latest_materialization:
+            latest_code_version = latest_materialization.asset_materialization.tags.get("dagster/code_version")
+            context.log.info(f"Latest code version for {asset_key}: {latest_code_version}")
+            current_code_version = get_current_dbt_code_version(asset_key)  # Implement this function to get the current code version
+            context.log.info(f"Current code version for {asset_key}: {current_code_version}")
+            if latest_code_version != current_code_version:
+                assets_to_materialize.append(asset_key)
+    context.log.info(f"Assets to materialize: {assets_to_materialize}")
+    if assets_to_materialize:
+        yield RunRequest(
+            run_key=f"code_version_update_{datetime.now()}",
+            asset_selection=list(assets_to_materialize)
+            )
+    # if never materialized before, materialize all
+    # currently doesn't work
+    # else:
+    #     yield RunRequest(
+    #         run_key=f"code_version_update_{datetime.now()}",
+    #         asset_selection=list(views_dbt_assets.keys) 
+    #     )

--- a/hooli_data_eng/utils/dbt_code_version.py
+++ b/hooli_data_eng/utils/dbt_code_version.py
@@ -1,0 +1,13 @@
+import hashlib
+import json
+from dagster import AssetKey
+from dagster_dbt import dbt_project
+
+def get_current_dbt_code_version(asset_key: AssetKey) -> str:
+    with open(dbt_project.manifest_path) as f:
+        manifest = json.load(f)
+    
+    model_name = asset_key.path[-1]
+    model_sql = manifest["nodes"][f"model.dbt_project.{model_name}"]["raw_code"]
+    
+    return hashlib.sha1(model_sql.encode("utf-8")).hexdigest()

--- a/hooli_data_eng/utils/dbt_code_version.py
+++ b/hooli_data_eng/utils/dbt_code_version.py
@@ -1,7 +1,7 @@
 import hashlib
 import json
 from dagster import AssetKey
-from dagster_dbt import dbt_project
+from hooli_data_eng.project import dbt_project
 
 def get_current_dbt_code_version(asset_key: AssetKey) -> str:
     with open(dbt_project.manifest_path) as f:


### PR DESCRIPTION
This PR adds a sensor that evaluates the hash value of the current state of the dbt code against the code version of the previous materialization. This is a way that you could leave dbt views unscheduled but update them anytime there is a change in the code.

I don't think this is absolutely core functionality for the demo project, but it has come up a few times and I wanted to show a solid solution in this space