### PR TITLE
Add prepare if dev dbt

### DIFF
--- a/dbt_project/dbt_project.yml
+++ b/dbt_project/dbt_project.yml
@@ -24,7 +24,7 @@ models:
       +group: Programmers
     CLEANED:
       +group: Programmers
-      +tags: "all_cleanred_models"
+      +tags: "all_cleaned_models"
     FORECASTING:
       +group: Stakeholders
     MARKETING:

--- a/hooli_data_eng/project.py
+++ b/hooli_data_eng/project.py
@@ -19,3 +19,4 @@ dbt_project = DbtProject(
     state_path="target/slim_ci",
     target=get_env(),
 )
+dbt_project.prepare_if_dev()

--- a/hooli_data_eng/resources/__init__.py
+++ b/hooli_data_eng/resources/__init__.py
@@ -40,8 +40,6 @@ from unittest import mock
 #
 # The production deployment on Dagster Cloud uses production Snowflake
 # and S3 resources
-
-
 client = mock.MagicMock()
 
 if get_env() == "PROD":
@@ -67,7 +65,7 @@ resource_def = {
         "output_notebook_io_manager": ConfigurableLocalOutputNotebookIOManager(),
         "api": RawDataAPI.configure_at_launch(),
         "s3": ResourceDefinition.none_resource(),
-        "dbt": DbtCliClientResource(project_dir=DBT_PROJECT_DIR, target="LOCAL"),
+        "dbt": DbtCliResource(project_dir=dbt_project, target="LOCAL"),
         "dbt2": DbtCliResource(project_dir=dbt_project, target="LOCAL"),
         "pyspark": pyspark_resource,
         "step_launcher": ResourceDefinition.none_resource(),
@@ -92,7 +90,7 @@ resource_def = {
         ),
         "output_notebook_io_manager": ConfigurableLocalOutputNotebookIOManager(),
         "api": RawDataAPI.configure_at_launch(),
-        "dbt": DbtCliClientResource(project_dir=DBT_PROJECT_DIR, target="BRANCH"),
+        "dbt": DbtCliResource(project_dir=dbt_project, target="BRANCH"),
         "dbt2": DbtCliResource(project_dir=dbt_project, target="BRANCH"),
         "pyspark": pyspark_resource,
         "step_launcher": db_step_launcher,
@@ -117,8 +115,8 @@ resource_def = {
         ),
         "output_notebook_io_manager": ConfigurableLocalOutputNotebookIOManager(),
         "api": RawDataAPI.configure_at_launch(),
-        "dbt": DbtCliClientResource(project_dir=DBT_PROJECT_DIR, target="PROD"),
-        "dbt2": DbtCliResource(project_dir=DBT_PROJECT_DIR, target="PROD"),
+        "dbt": DbtCliResource(project_dir=dbt_project, target="PROD"),
+        "dbt2": DbtCliResource(project_dir=dbt_project, target="PROD"),
         "pyspark": pyspark_resource,
         "step_launcher": db_step_launcher,
         "monitor_fs": s3FileSystem(region_name="us-west-2", s3_bucket="hooli-demo"),


### PR DESCRIPTION
Per the docs of [1.7.13](https://github.com/dagster-io/dagster/releases/tag/1.7.13):

> [dagster-dbt] During development,DbtProject no longer prepares the dbt manifest file and dbt dependencies in its constructor during initialization. This process has been moved to prepare_if_dev(), that can be called on the DbtProject instance after initialization. Check out the API docs for more: [https://docs.dagster.io/_apidocs/libraries/dagster-dbt#dagster_dbt.DbtProject.prepare_if_dev](https://docs.dagster.io/_apidocs/libraries/dagster-dbt#dagster_dbt.DbtProject.prepare_if_devhttps://docs.dagster.io/_apidocs/libraries/dagster-dbt#dagster_dbt.DbtProject.prepare_if_dev).

@izzye84  already did the other piece in #100, of switching the dagster-dbt CLI arguments. 

This won't have an impact on branch deployments or our data-eng-prod deployment, but will be useful for local dev