### PR TITLE
bump to 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 WORKDIR /opt/dagster/app
 

--- a/hooli-demo-assets/Dockerfile
+++ b/hooli-demo-assets/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.11-slim
 
 WORKDIR /opt/dagster/app
 

--- a/hooli_basics/Dockerfile
+++ b/hooli_basics/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.12-slim
 
 WORKDIR /opt/dagster/app
 

--- a/hooli_batch_enrichment/Dockerfile
+++ b/hooli_batch_enrichment/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.12-slim
 
 WORKDIR /opt/dagster/app
 

--- a/hooli_snowflake_insights/Dockerfile
+++ b/hooli_snowflake_insights/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.12-slim
 
 WORKDIR /opt/dagster/app
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ from setuptools import find_packages, setup
 if __name__ == "__main__":
     setup(
         name="hooli_data_eng",
-        python_requires='<3.12',
         packages=find_packages(exclude=["hooli_data_eng_tests"]),
         package_data={"hooli_data_eng": ["dbt_project/*"]},
         install_requires=[


### PR DESCRIPTION
bumps images to use python 3.12 except for one code location (to show that we don't have to run the same versions). 

Also bumps to dagster 1.7.14