### PR TITLE
use stream definition for group

### DIFF
--- a/hooli-demo-assets/hooli_demo_assets/assets/sling.py
+++ b/hooli-demo-assets/hooli_demo_assets/assets/sling.py
@@ -14,7 +14,10 @@ class CustomSlingTranslator(DagsterSlingTranslator):
         self.replication_config = replication_config
         
    def get_group_name(self, stream_definition):
-       return "RAW_DATA"
+      for key, value in stream_definition['config'].items():
+         if value == 'locations':
+            group_name = 'RAW_DATA'
+      return group_name
    
    def get_tags(self, stream_definition):
        # derive storage_kind from the target set in the replication_config


### PR DESCRIPTION
Small change, but useful to show how you could use the stream_definition to determine the asset group name (similar to how we do so with dbt metadata

format of `stream_definition` looks like:

```python
      # stream_definition example 
      # {'name': 's3://hooli-demo/embedded-elt/locations.csv', 'config': {'object': 'locations'}}
```

