### PR TITLE
add default config so scheduled job will run

### DIFF
--- a/hooli_batch_enrichment/dagster_batch_enrichment/assets.py
+++ b/hooli_batch_enrichment/dagster_batch_enrichment/assets.py
@@ -11,7 +11,10 @@ from dagster_batch_enrichment.api import EnrichmentAPI
 
 
 class experimentConfig(Config):
-    experiment_name: str
+    experiment_name: str = Field(
+        default="default_config", 
+        description="A name to give to this run's configuration set"
+    )
 
 @asset(
     compute_kind="Kubernetes",


### PR DESCRIPTION
this scheduled run has been broken for a long time because we introduced required user config with no default

this PR fixes that