### PR TITLE
change dbt target resolution

### DIFF
--- a/hooli-demo-assets/hooli_demo_assets/resources/__init__.py
+++ b/hooli-demo-assets/hooli_demo_assets/resources/__init__.py
@@ -9,11 +9,12 @@ from dagster_embedded_elt.sling import (
 
 
 def get_env():
-   if os.getenv("DAGSTER_CLOUD_IS_BRANCH_DEPLOYMENT", "") == "1":
-       return "BRANCH"
-   if os.getenv("DAGSTER_CLOUD_DEPLOYMENT_NAME", "") == "data-eng-prod":
-       return "PROD"
-   return "LOCAL"
+    if os.getenv("DAGSTER_CLOUD_DEPLOYMENT_NAME", "") == "data-eng-prod":
+        return "PROD"
+    if os.getenv("DAGSTER_IS_DEV_CLI"):
+        return "LOCAL"
+    # default to BRANCH so we use that in github CI
+    return "BRANCH"
 
 
 # Path for duckdb connection - needed for local dev


### PR DESCRIPTION
to ensure that we always target `"BRANCH"` in github action CI, let it be the default of `get_env` and instead detect local development by looking for the `dagster dev` env var