### PR TITLE
add install_from_dagster_clone makefile command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,9 @@ stateful_dev_prod: clean manifest
 
 dependencies:
 	uv pip install -e ".[dev]"
+
+# ensure that DAGSTER_GIT_REPO_DIR is set to the path of the dagster repo
+# see https://www.notion.so/dagster/Local-Dev-Setup-e58aba352f704dcc88a8dc44cb1ce7fc for more details
+# ensure your virtual environment is activated here
+install_from_dagster_clone:
+	source .venv/bin/activate; uv pip install pip; cd ${DAGSTER_GIT_REPO_DIR} && python scripts/install_dev_python_modules.py; cd -; 


### PR DESCRIPTION
I am lazy. 

Sometimes I want to dogfood / try out unreleased versions of Dagster in hooli, and my process annoyed me

old process:

`cd $DAGSTER_GIT_REPO_DIR`
`make dev_install`
wait
`cd -`

proposed process:
`make install_from_dagster_clone`
profit
