### PR TITLE
Correctly upgrade pip in hooli CI/CD

### DIFF
--- a/.github/workflows/deploy-dagster-cloud.yml
+++ b/.github/workflows/deploy-dagster-cloud.yml
@@ -78,8 +78,8 @@ jobs:
       - name: Prepare dbt project
         if: steps.prerun.outputs.result != 'skip'
         run: |
-          pip install pip --upgrade;
-          pip install dagster-dbt dagster-cloud dbt-core dbt-duckdb dbt-snowflake grpcio-health-checking==1.64.3 --upgrade --upgrade-strategy eager;
+          python -m pip install pip --upgrade;
+          pip install dagster-dbt dagster-cloud dbt-core dbt-duckdb dbt-snowflake --upgrade --upgrade-strategy eager;
           make deps
           dagster-dbt project prepare-and-package --file hooli_data_eng/project.py
           dagster-cloud ci dagster-dbt project manage-state --file hooli_data_eng/project.py --source-deployment data-eng-prod


### PR DESCRIPTION
Summary:
For reasons that are not entirely clear to me, the previous command was leaving pip on 20.0.2 and not actually upgrading it.

Test Plan: Should now build and deploy without CI/CD hack
