### PR TITLE
add column metadata and lineage to sling

### DIFF
--- a/hooli-demo-assets/hooli_demo_assets/assets/sling.py
+++ b/hooli-demo-assets/hooli_demo_assets/assets/sling.py
@@ -29,6 +29,6 @@ class CustomSlingTranslator(DagsterSlingTranslator):
    dagster_sling_translator=CustomSlingTranslator(),
 )
 def my_sling_assets(context, sling: SlingResource):
-   yield from sling.replicate(context=context)
+   yield from sling.replicate(context=context).fetch_column_metadata()
    for row in sling.stream_raw_logs():
        context.log.info(row)

--- a/hooli-demo-assets/hooli_demo_assets/assets/sling.py
+++ b/hooli-demo-assets/hooli_demo_assets/assets/sling.py
@@ -29,6 +29,6 @@ class CustomSlingTranslator(DagsterSlingTranslator):
    dagster_sling_translator=CustomSlingTranslator(),
 )
 def my_sling_assets(context, sling: SlingResource):
-   yield from sling.replicate(context=context).fetch_column_metadata()
+   yield from sling.replicate(context=context).fetch_column_metadata().fetch_row_count()
    for row in sling.stream_raw_logs():
        context.log.info(row)


### PR DESCRIPTION
released in 1.8.1, sling assets can now show column level lineage and column metadata.

Will add row count once the release it live this week or next