### PR TITLE
dbt blueprints example

### DIFF
--- a/hooli_data_eng/blueprints/blueprints.py
+++ b/hooli_data_eng/blueprints/blueprints.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+from typing import Literal, Optional
+
+from dagster import define_asset_job, Definitions, ScheduleDefinition
+from dagster_blueprints import YamlBlueprintsLoader
+from dagster_blueprints.blueprint import Blueprint
+from dagster_dbt import build_dbt_asset_selection
+
+from hooli_data_eng.assets.dbt_assets import daily_dbt_assets
+
+# This class is used to construct dbt jobs via yaml files
+
+class DbtSelectScheduledJobBlueprint(Blueprint):
+    type: Literal["dbt_select_job"]
+    name: str
+    select: str
+    exclude: Optional[str]
+    cron: str
+
+    def build_defs(self) -> Definitions:
+        job_def = define_asset_job(
+            name=self.name,
+            selection=build_dbt_asset_selection(
+                [daily_dbt_assets], dbt_select=self.select, dbt_exclude=self.exclude
+            ),
+        )
+        schedule_def = ScheduleDefinition(job=job_def, cron_schedule=self.cron)
+        return Definitions(schedules=[schedule_def])
+
+# The loader will pick up any yaml files in the blueprints_jobs directory
+loader = YamlBlueprintsLoader(
+    per_file_blueprint_type=DbtSelectScheduledJobBlueprint,
+    path=Path(__file__).parent / "blueprints_jobs",
+)

--- a/hooli_data_eng/blueprints/blueprints_jobs/dbt_job.yaml
+++ b/hooli_data_eng/blueprints/blueprints_jobs/dbt_job.yaml
@@ -1,0 +1,5 @@
+type: dbt_select_job
+name: dbt_blueprints_job
+select: "tag:all_cleaned_models"
+exclude:
+cron: 0 8 * * *

--- a/hooli_data_eng/definitions.py
+++ b/hooli_data_eng/definitions.py
@@ -15,6 +15,7 @@ from hooli_data_eng.assets import forecasting, raw_data, marketing, dbt_assets
 from hooli_data_eng.assets.dbt_assets import dbt_slim_ci_job
 from hooli_data_eng.assets.marketing import check_avg_orders
 from hooli_data_eng.assets.raw_data import check_users, raw_data_schema_checks
+from hooli_data_eng.blueprints.blueprints import loader
 from hooli_data_eng.jobs import analytics_job, predict_job
 from hooli_data_eng.resources import get_env, resource_def
 from hooli_data_eng.schedules import analytics_schedule
@@ -65,7 +66,8 @@ marketing_assets = load_assets_from_package_module(marketing, group_name="MARKET
 # Definitions are the collection of assets, jobs, schedules, resources, and sensors
 # used with a project. Dagster Cloud deployments can contain mulitple projects.
 
-defs = Definitions(
+# Use Definitions.merge to include blueprints definitions
+defs = Definitions.merge(loader.load_defs(), Definitions(
     executor=multiprocess_executor.configured(
         {"max_concurrent": 3}
     ),  
@@ -88,4 +90,5 @@ defs = Definitions(
        weekly_freshness_check_sensor
     ],
     jobs=[analytics_job, predict_job, dbt_slim_ci_job],
+    )
 )

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ if __name__ == "__main__":
         install_requires=[
             "dagster",
             "dagster-dbt",
+            "dagster-blueprints",
             "pandas",
             "numpy",
             "scipy",


### PR DESCRIPTION
This blueprints example constructs a dbt job for any yaml file with the appropriate config under the `hooli_data_eng/blueprints/blueprints_jobs/` directory—the job config is defined by the `DbtSelectScheduledJobBlueprint` class.  

<img width="1716" alt="dbt_blueprints_job" src="https://github.com/user-attachments/assets/31a003ac-996c-4542-b791-7e12cdb99000">

