### PR TITLE
Add source freshness checks to upstream assets

### DIFF
--- a/dbt_project/models/sources.yml
+++ b/dbt_project/models/sources.yml
@@ -5,6 +5,13 @@ sources:
     tables:
       - name: "orders"
         loaded_at_field: dt
+        freshness:
+          warn_after:
+            count: 1 # orders and users will warn daily and error after 2 days
+            period: day #minute | hour | day
+          error_after:
+            count: 1
+            period: day #minute | hour | day
         columns:
           - name: "order_id"
             tests:
@@ -15,10 +22,10 @@ sources:
         loaded_at_field: "to_timestamp(_sling_loaded_at)"
     freshness:
       warn_after:
-        count: 3 # orders and users will warn daily and error after 2 days
+        count: 2 # orders and users will warn daily and error after 2 days
         period: day #minute | hour | day
       error_after:
-        count: 4
+        count: 3
         period: day #minute | hour | day
       #filter: <boolean_sql_expression>
   - name: "forecasting"

--- a/dbt_project/models/sources.yml
+++ b/dbt_project/models/sources.yml
@@ -4,8 +4,23 @@ sources:
   - name: "raw_data"
     tables:
       - name: "orders"
+        loaded_at_field: dt
+        columns:
+          - name: "order_id"
+            tests:
+              - unique
       - name: "users"
+        loaded_at_field: created_at
       - name: "locations"
+        loaded_at_field: "to_timestamp(_sling_loaded_at)"
+    freshness:
+      warn_after:
+        count: 3 # orders and users will warn daily and error after 2 days
+        period: day #minute | hour | day
+      error_after:
+        count: 4
+        period: day #minute | hour | day
+      #filter: <boolean_sql_expression>
   - name: "forecasting"
     tables:
       - name: "predicted_orders"

--- a/hooli_data_eng/assets/dbt_assets.py
+++ b/hooli_data_eng/assets/dbt_assets.py
@@ -1,6 +1,9 @@
 import json
 import textwrap
-from typing import Any, Mapping
+from typing import Any, Mapping, Iterable
+import subprocess
+import re
+
 from dagster import (
     AutomationCondition,
     AssetKey,
@@ -10,6 +13,11 @@ from dagster import (
     op,
     AssetExecutionContext,
     WeeklyPartitionsDefinition,
+    AssetCheckExecutionContext,
+    AssetCheckResult,
+    AssetCheckSpec,
+    multi_asset_check,
+    AssetCheckSeverity,
 )
 from dagster_cloud.dagster_insights import dbt_with_snowflake_insights
 from dagster_dbt import (
@@ -17,11 +25,67 @@ from dagster_dbt import (
     DagsterDbtTranslator,
     default_metadata_from_dbt_resource_props,
     DagsterDbtTranslatorSettings,
+    DbtCliEventMessage
 )
+
 from dagster_dbt.asset_decorator import dbt_assets
 from hooli_data_eng.resources import dbt_project
 from dagster_dbt.freshness_builder import build_freshness_checks_from_dbt_assets
 from dagster import build_sensor_for_freshness_checks
+
+# Load and parse the dbt manifest
+def load_dbt_manifest(manifest_path):
+    with open(manifest_path, 'r') as f:
+        manifest = json.load(f)
+    return manifest
+
+# Create AssetCheckSpec objects from the dbt manifest
+def create_source_freshness_check_specs(manifest_path):
+    manifest = load_dbt_manifest(manifest_path)
+    check_specs = []
+    for _, source_data in manifest['sources'].items():
+        if "freshness" in source_data and source_data["freshness"] is not None:
+            # Append check_specs as it currently is
+            asset_key = AssetKey([source_data["schema"].upper(), source_data["name"] ])
+            check_specs.append(
+                AssetCheckSpec(
+                    name="source_freshness_check",
+                    asset=asset_key,
+                    automation_condition=AutomationCondition.eager()),
+            )
+    return check_specs
+
+
+@multi_asset_check(
+    specs=create_source_freshness_check_specs(dbt_project.manifest_path),
+    can_subset=True,
+    required_resource_keys={"dbt"},
+)
+def source_freshness_check(context: AssetCheckExecutionContext):
+    dbt_resource = context.resources.dbt
+    for asset_check_key in context.selected_asset_check_keys:
+        # Extract the asset key and check name
+        asset_key = asset_check_key.asset_key
+        check_name = asset_check_key.name
+        context.log.info(f"Running check {check_name} on asset {asset_key}")
+        selection_string = f"source:{asset_key.path[0].lower()}.{asset_key.path[1]}"
+        dbt_cli_invocation = dbt_resource.cli(["source", "freshness", "--select", selection_string], raise_on_error=False)
+        # Process the raw event stream
+        for dbt_event in dbt_cli_invocation.stream_raw_events():
+            context.log.info(f"Received event: {dbt_event.raw_event}")
+            if dbt_event.raw_event.get('info', {}).get('name') == 'LogFreshnessResult':
+                log_freshness_result = dbt_event.raw_event['info']
+                context.log.info(f"Filtered LogFreshnessResult: {log_freshness_result}")
+                passed = True if log_freshness_result['level'] == 'info' else False
+                severity = AssetCheckSeverity.ERROR if log_freshness_result['level'] == 'error' else AssetCheckSeverity.WARN
+                yield AssetCheckResult(
+                    asset_key=asset_key,
+                    check_name="source_freshness_check",
+                    passed=passed,
+                    severity=severity,
+                    metadata={},
+                )
+
 
 
 # many dbt assets use an incremental approach to avoid
@@ -115,7 +179,6 @@ class CustomDagsterDbtTranslator(DagsterDbtTranslator):
             dbt_resource_props["group"]["owner"]["email"],
             f"team:{dbt_resource_props['group']['name']}",
         ]
-
 
 def _process_partitioned_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
     # map partition key range to dbt vars
@@ -211,6 +274,8 @@ def regular_dbt_assets(context: AssetExecutionContext, dbt: DbtCliResource):
     for result in run_results_json["results"]:
         model_name = result.get("unique_id")
         context.log.info(f"Compiled SQL for {model_name}:\n{result['compiled_code']}")
+
+
 
 
 # This op will be used to run slim CI

--- a/hooli_data_eng/definitions.py
+++ b/hooli_data_eng/definitions.py
@@ -3,6 +3,7 @@ from dagster import (
     AnchorBasedFilePathMapping,
     Definitions,
     load_assets_from_modules,
+    load_asset_checks_from_modules,
     load_assets_from_package_module,
     build_column_schema_change_checks,
     multiprocess_executor,
@@ -45,6 +46,7 @@ raw_data_assets = load_assets_from_package_module(
 # specifies what databases to targets, and locally will
 # execute against a DuckDB
 
+dbt_source_freshness = load_asset_checks_from_modules([dbt_assets])
 dbt_assets = load_assets_from_modules([dbt_assets])
 
 dbt_asset_checks = build_column_schema_change_checks(assets=[*dbt_assets])
@@ -77,7 +79,7 @@ defs = Definitions.merge(loader.load_defs(), Definitions(
             file_anchor_path_in_repository="hooli_data_eng/definitions.py"
         )
     ),
-    asset_checks=[*raw_data_schema_checks, *dbt_asset_checks, check_users, check_avg_orders, *min_order_freshness_check, *avg_orders_freshness_check, *weekly_freshness_check],
+    asset_checks=[*raw_data_schema_checks, *dbt_asset_checks, *dbt_source_freshness, check_users, check_avg_orders, *min_order_freshness_check, *avg_orders_freshness_check, *weekly_freshness_check],
     resources=resource_def[get_env()],
     schedules=[analytics_schedule, avg_orders_freshness_check_schedule],
     sensors=[


### PR DESCRIPTION
This PR was a learning experience for me. Sometimes we hear from prospects that they really like using [dbt source freshness](https://docs.getdbt.com/reference/commands/source) and would like to continue doing so with Dagster. This PR demonstrates how you would add a custom dbt command to Dagster, namely:

* a multi asset check that automatically adds a dbt source freshness check when there is a source freshness defined in the `sources.yml` manifest
* is a _blocking_ asset check, so that if the source isn't fresh it will not allow the downstream dbt step to run in `refresh_analytics_jop`   -- example below
* computes one `dbt freshness` for a set of dbt sources selected and then reports individual asset check status
<img width="1431" alt="image" src="https://github.com/user-attachments/assets/6970b87b-2f70-4a99-9d9a-caf72d504852" /> 
* demonstrates how you can add an automation condition to an asset check -- this one uses the `allow_outdated_and_missing_parents_condition`, which I confess to not really understanding but works. To demo this you have to run the `refresh_analytics_model_job` from the launchpad and un-select running the asset checks, and then it will run.

Totally fine if we choose not to add it in but it was fun to work through! One thing I wanted to investigate still is adding the proper metadata to it

