### PR TITLE
Exclude .github/ directory in Ruff formatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,3 +58,6 @@ packages = { find = { exclude = ["hooli_data_eng_tests"] } }
 
 [tool.setuptools.package-data]
 "hooli_data_eng" = ["dbt_project/*"]
+
+[tool.ruff]
+exclude = ["**/.github/**"]


### PR DESCRIPTION
The GitHub action erroneously performs `ruff` formatting on the `github` directory.

This introduces a Ruff configuration in `pyproject.toml` to exclude those files from being formatted.
