### PR TITLE
Suppress warnings in hooli dg cli

### DIFF
--- a/dg.toml
+++ b/dg.toml
@@ -23,3 +23,7 @@ path = "hooli-batch-enrichment"
 #[[workspace.projects]]
 #path = "hooli-airlift"
 
+[cli]
+suppress_warnings = [
+    "deprecated_dagster_dg_library_entry_point"
+]


### PR DESCRIPTION
Hooli is yelling at us during dg operations because it uses the old plugin entry point. This doesn't do any harm unless we want to demo the pyproject.toml itself.

Suppressing it for now.

Test Plan:

Before:

```
(hooli-data-eng) ➜  hooli-data-eng git:(master) dg list defs
Found deprecated `dagster_dg.plugin` entry point group in:
    /Users/schrockn/code/hooli-data-eng-pipelines/hooli-data-eng/pyproject.toml

Please update the group name to `dagster_dg_cli.registry_modules`. Package reinstallation is required
because entry points are registered at install time. Reinstall your package to your
environment using:

    [uv]  $ uv pip install -e .
    [pip] $ pip install -e .

To suppress this warning, add "deprecated_dagster_dg_library_entry_point" to the `cli.suppress_warnings` list in your configuration.
```

After:
```
(hooli-data-eng) ➜  hooli-data-eng git:(schrockn/suppress-warnings) dg list defs
INFO:dagster.builtin:Running dbt command: `dbt parse --quiet --target LOCAL`.
INFO:dagster.builtin:Finished dbt command: `dbt parse --quiet --target LOCAL`.
```

```