### PR TITLE
updated the cron policies and added time based policies to the centra…

### DIFF
--- a/hooli-batch-enrichment/hooli_batch_enrichment/assets.py
+++ b/hooli-batch-enrichment/hooli_batch_enrichment/assets.py
@@ -21,9 +21,9 @@ from hooli_batch_enrichment.api import EnrichmentAPI
 from datetime import timedelta
 from dagster._core.definitions.freshness import InternalFreshnessPolicy
 
-# Define a freshness policy between 7:30PM and 8:30PM Pacific Time
+# Define a freshness policy for every hour Pacific Time
 cron_policy = InternalFreshnessPolicy.cron(
-    deadline_cron="30 20 * * *",
+    deadline_cron="0 * * * *",
     lower_bound_delta=timedelta(hours=1),
     timezone="America/Los_Angeles",
 )

--- a/hooli-data-eng/hooli_data_eng/defs/custom_ingest/assets.py
+++ b/hooli-data-eng/hooli_data_eng/defs/custom_ingest/assets.py
@@ -6,10 +6,10 @@ from hooli_data_eng.defs.custom_ingest.resources import RawDataAPI
 from hooli_data_eng.utils.kind_helpers import get_kind
 from dagster._core.definitions.freshness import InternalFreshnessPolicy
 
-# Define a freshness policy between 7:30PM and 8:30PM Pacific Time
+# Define a freshness policy before 8:30PM Pacific Time
 cron_policy = InternalFreshnessPolicy.cron(
     deadline_cron="30 20 * * *",
-    lower_bound_delta=timedelta(hours=1),
+    lower_bound_delta=timedelta(hours=23),
     timezone="America/Los_Angeles",
 )
 


### PR DESCRIPTION
…l data team

# 📊 Asset Policy Justification

## ✅ Overview

After a first pass test of the freshness policies, I have adjusted the freshness cron schedules to more closely match the materialization cadence.

I have also added time window freshness policies to dbt assets.

---

## 1. 📅 Simulating Realistic Ingest Timing with Cron Policies

Cron-based policies are used to simulate fixed ingestion times, emulating patterns such as:

- Scheduled file drops from external sources (e.g., daily CSV uploads)
- Batch ingestion from upstream systems or APIs

Benefits of this setup:
- Provides a **stable execution anchor** for downstream processing
- Enables **testing of time-sensitive dependencies**
- Reflects batch-like processes common in enterprise data environments

---

## 🕒 Applied Cron Policies

The following assets are configured with **cron-based policies** to simulate scheduled data ingest cycles:

- **`users`**
- **`orders`**
  - **Group:** `RAW_DATA`
  - **File:** `../hooli-data-eng/hooli_data_eng/defs/custom_ingest/assets.py`
- **`raw_data`**
  - **File:** `../hooli-batch-enrichment/hooli_batch_enrichment/assets.py`

---

## 2. ⏱ Modeling Data Latency with Time Window Freshness Policies

After ingest, downstream assets use **time window freshness policies** to reflect different SLA needs across teams:

- **Tight freshness windows** for real-time or operational use cases (e.g., monitoring dashboards, alerts)
- **Relaxed windows** for batch workloads (e.g., marketing, analytics)
- **Incrementally widening freshness windows** to simulate SLA drift and long-tail latency

A **time window freshness policy** is particularly useful when:
- Assets are expected to be **recalculated on a regular cadence**
- Data consumers need **guarantees of freshness**
- You want **re-materialization** to occur automatically if freshness lags

---

## 🕒 Applied Time Window Freshness Policies

The following dynamically generated assets(regular_dbt_assets, daily_dbt_assets and weekly_dbt_assets) are configured with **time window freshness policies** to simulate scheduled data ingest cycles:

- **`regular_dbt_assets`**
  - **frequency:** `7 day fail, 3 day warning`
- **`daily_dbt_assets`**
  - **frequency:** `24 hour fail, 12 hour warning`
- **`weekly_dbt_assets`**
  - **frequency:** `7 day fail, 2 day warning`

- **File:** `../hooli-data-eng/hooli_data_eng/defs/dbt/component.py`

**`Especially review how this is implemented as there is no API information I found`**

---

## 🎯 Justification for Asset Policies

The motivation for defining multiple assets with specific asset policies is to simulate **real-world data behavior** and ensure pipelines align with:
- Expected **data availability**
- Typical **processing cycles**
- Diverse **consumer SLA needs**

This architecture promotes operational accuracy and supports **freshness guarantees** across the pipeline.

---
