### PR TITLE
WIP - Fixed broken code links

### DIFF
--- a/hooli-basics/hooli_basics/definitions.py
+++ b/hooli-basics/hooli_basics/definitions.py
@@ -65,7 +65,7 @@ defs = Definitions(
         with_source_code_references([country_stats, continent_stats, change_model]),
         file_path_mapping=AnchorBasedFilePathMapping(
             local_file_anchor=Path(__file__),
-            file_anchor_path_in_repository="hooli_basics/definitions.py",
+            file_anchor_path_in_repository="hooli-basics/hooli_basics/definitions.py",
         ),
     ),
     asset_checks=[check_country_stats],

--- a/hooli-bi/hooli_bi/definitions.py
+++ b/hooli-bi/hooli_bi/definitions.py
@@ -1,9 +1,23 @@
-from dagster import Definitions
+from pathlib import Path
+
+from dagster import (
+    AnchorBasedFilePathMapping,
+    Definitions,
+    with_source_code_references
+)
+
+from dagster_cloud.metadata.source_code import link_code_references_to_git_if_cloud
 
 from hooli_bi.powerbi_assets import powerbi_assets  # noqa: TID252
 from hooli_bi.powerbi_workspace import power_bi_workspace
 
 defs = Definitions(
-    assets=[*powerbi_assets],
+    assets=link_code_references_to_git_if_cloud(
+        with_source_code_references([*powerbi_assets]),
+        file_path_mapping=AnchorBasedFilePathMapping(
+            local_file_anchor=Path(__file__),
+            file_anchor_path_in_repository="hooli-bi/hooli_bi/definitions.py",
+        ),
+    ),
     resources={"power_bi": power_bi_workspace},
 )

--- a/hooli-data-eng/hooli_data_eng/defs/custom_ingest/definitions.py
+++ b/hooli-data-eng/hooli_data_eng/defs/custom_ingest/definitions.py
@@ -25,7 +25,7 @@ defs = dg.Definitions(
         ),
         file_path_mapping=dg.AnchorBasedFilePathMapping(
             local_file_anchor=Path(__file__),
-            file_anchor_path_in_repository="hooli_data_eng/definitions.py",
+            file_anchor_path_in_repository="hooli_data_eng/defs/custom_ingest/definitions.py",
         ),
     ),
     asset_checks=[

--- a/hooli-data-eng/hooli_data_eng/defs/databricks/definitions.py
+++ b/hooli-data-eng/hooli_data_eng/defs/databricks/definitions.py
@@ -24,7 +24,7 @@ defs = dg.Definitions(
         ),
         file_path_mapping=dg.AnchorBasedFilePathMapping(
             local_file_anchor=Path(__file__),
-            file_anchor_path_in_repository="hooli_data_eng/databricks/definitions.py",
+            file_anchor_path_in_repository="hooli_data_eng/defs/databricks/definitions.py",
         ),
     ),
     resources=resource_def[get_env()],

--- a/hooli-data-eng/hooli_data_eng/defs/files/definitions.py
+++ b/hooli-data-eng/hooli_data_eng/defs/files/definitions.py
@@ -23,7 +23,7 @@ defs = dg.Definitions(
         ),
         file_path_mapping=dg.AnchorBasedFilePathMapping(
             local_file_anchor=Path(__file__),
-            file_anchor_path_in_repository="hooli_data_eng/files/definitions.py",
+            file_anchor_path_in_repository="hooli_data_eng/defs/files/definitions.py",
         ),
     ),
     resources=resource_def[get_env()],

--- a/hooli-data-eng/hooli_data_eng/defs/kubernetes/definitions.py
+++ b/hooli-data-eng/hooli_data_eng/defs/kubernetes/definitions.py
@@ -20,7 +20,7 @@ defs = dg.Definitions(
         ),
         file_path_mapping=dg.AnchorBasedFilePathMapping(
             local_file_anchor=Path(__file__),
-            file_anchor_path_in_repository="hooli_data_eng/kubernetes/definitions.py",
+            file_anchor_path_in_repository="hooli_data_eng/defs/kubernetes/definitions.py",
         ),
     ),
     resources=resource_def[get_env()],

--- a/hooli-data-eng/hooli_data_eng/defs/notebooks/definitions.py
+++ b/hooli-data-eng/hooli_data_eng/defs/notebooks/definitions.py
@@ -20,7 +20,7 @@ defs = dg.Definitions(
         ),
         file_path_mapping=dg.AnchorBasedFilePathMapping(
             local_file_anchor=Path(__file__),
-            file_anchor_path_in_repository="hooli_data_eng/notebooks/definitions.py",
+            file_anchor_path_in_repository="hooli_data_eng/defs/notebooks/definitions.py",
         ),
     ),
     resources=resource_def[get_env()],

--- a/hooli-data-eng/hooli_data_eng/defs/pandas/definitions.py
+++ b/hooli-data-eng/hooli_data_eng/defs/pandas/definitions.py
@@ -28,7 +28,7 @@ defs = dg.Definitions(
         ),
         file_path_mapping=dg.AnchorBasedFilePathMapping(
             local_file_anchor=Path(__file__),
-            file_anchor_path_in_repository="hooli_data_eng/pandas/definitions.py",
+            file_anchor_path_in_repository="hooli_data_eng/defs/pandas/definitions.py",
         ),
     ),
     asset_checks=[*pandas_checks],

--- a/hooli-data-eng/hooli_data_eng/defs/scikit_learn/definitions.py
+++ b/hooli-data-eng/hooli_data_eng/defs/scikit_learn/definitions.py
@@ -19,7 +19,7 @@ defs = dg.Definitions(
         ),
         file_path_mapping=dg.AnchorBasedFilePathMapping(
             local_file_anchor=Path(__file__),
-            file_anchor_path_in_repository="hooli_data_eng/scikit_learn/definitions.py",
+            file_anchor_path_in_repository="hooli_data_eng/defs/scikit_learn/definitions.py",
         ),
     ),
     resources=resource_def[get_env()],

--- a/hooli-snowflake-insights/hooli_snowflake_insights/definitions.py
+++ b/hooli-snowflake-insights/hooli_snowflake_insights/definitions.py
@@ -61,7 +61,7 @@ defs = Definitions(
         ),
         file_path_mapping=AnchorBasedFilePathMapping(
             local_file_anchor=Path(__file__),
-            file_anchor_path_in_repository="hooli_snowflake_insights/definitions.py",
+            file_anchor_path_in_repository="hooli-snowflake-insights/hooli_snowflake_insights/definitions.py",
         ),
     ),
     schedules=[


### PR DESCRIPTION
Code links stopped working for most assets after we restructured the hooli repo.  Updated the file anchor paths to reflect the new project structure.