### PR TITLE
fixed bug for non-partitioned dbt assets

### DIFF
--- a/hooli-data-eng/hooli_data_eng/defs/dbt/component.py
+++ b/hooli-data-eng/hooli_data_eng/defs/dbt/component.py
@@ -123,10 +123,15 @@ class CustomDagsterDbtTranslator(DagsterDbtTranslator):
 def _process_partitioned_dbt_assets(
     context: dg.AssetExecutionContext, dbt: DbtCliResource
 ):
-    # map partition key range to dbt vars
-    first_partition, last_partition = context.partition_time_window
-    dbt_vars = {"min_date": str(first_partition), "max_date": str(last_partition)}
-    dbt_args = ["build", "--vars", json.dumps(dbt_vars)]
+    # Check if the asset is partitioned
+    if context.has_partition_key:
+        # map partition key range to dbt vars
+        first_partition, last_partition = context.partition_time_window
+        dbt_vars = {"min_date": str(first_partition), "max_date": str(last_partition)}
+        dbt_args = ["build", "--vars", json.dumps(dbt_vars)]
+    else:
+        # if not partitioned, use default dbt build command
+        dbt_args = ["build"]
 
     # Invoke dbt CLI
     dbt_cli_task = dbt.cli(dbt_args, context=context)


### PR DESCRIPTION
Moving dbt assets to a component introduced a bug for non-partitioned dbt assets that result in an error—`dagster._core.errors.DagsterInvariantViolationError: Partitions definition is not defined`.  

This PR fixes that bug by conditionally checking if the underlying asset has partitions before invoking the `dbt build` command.