### PR TITLE
use private key instead of password for snowflake

### DIFF
--- a/dbt_project/profiles.yml
+++ b/dbt_project/profiles.yml
@@ -10,10 +10,9 @@ dbt_project:
       type: snowflake
       account: "{{ env_var('SNOWFLAKE_ACCOUNT', '') }}"
 
-      # User/password auth
+      # User/private_key auth
       user: "{{ env_var('SNOWFLAKE_USER', '') }}"
-      password: "{{ env_var('SNOWFLAKE_PASSWORD', '') }}"
-
+      private_key: "{{ env_var('SNOWFLAKE_KEY', '') }}"
       database: DEMO_DB2
       warehouse: TINY_WAREHOUSE
       schema: analytics
@@ -23,9 +22,9 @@ dbt_project:
       type: snowflake
       account: "{{ env_var('SNOWFLAKE_ACCOUNT', '') }}"
 
-      # User/password auth
+      # User/private_key auth
       user: "{{ env_var('SNOWFLAKE_USER', '') }}"
-      password: "{{ env_var('SNOWFLAKE_PASSWORD', '') }}"
+      private_key: "{{ env_var('SNOWFLAKE_KEY', '') }}"
 
       database: DEMO_DB2_BRANCH
       warehouse: TINY_WAREHOUSE

--- a/hooli-data-eng/src/hooli_data_eng/defs/databricks/resources.py
+++ b/hooli-data-eng/src/hooli_data_eng/defs/databricks/resources.py
@@ -84,8 +84,8 @@ db_step_launcher = databricks_pyspark_step_launcher.configured(
                 "scope": "dagster-test",
             },
             {
-                "name": "SNOWFLAKE_PASSWORD",
-                "key": "snowflake_password",
+                "name": "SNOWFLAKE_KEY",
+                "key": "snowflake_key",
                 "scope": "dagster-test",
             },
             {

--- a/hooli-data-eng/src/hooli_data_eng/resources.py
+++ b/hooli-data-eng/src/hooli_data_eng/resources.py
@@ -19,7 +19,7 @@ snowflake_branch_io_manager = SnowflakePandasIOManager(
     database="DEMO_DB2_BRANCH",
     account=dg.EnvVar("SNOWFLAKE_ACCOUNT"),
     user=dg.EnvVar("SNOWFLAKE_USER"),
-    password=dg.EnvVar("SNOWFLAKE_PASSWORD"),
+    private_key=dg.EnvVar("SNOWFLAKE_KEY"),
     warehouse="TINY_WAREHOUSE",
 )
 
@@ -27,6 +27,6 @@ snowflake_prod_io_manager = SnowflakePandasIOManager(
     database="DEMO_DB2",
     account=dg.EnvVar("SNOWFLAKE_ACCOUNT"),
     user=dg.EnvVar("SNOWFLAKE_USER"),
-    password=dg.EnvVar("SNOWFLAKE_PASSWORD"),
+    private_key=dg.EnvVar("SNOWFLAKE_KEY"),
     warehouse="TINY_WAREHOUSE",
 )

--- a/hooli-data-ingest/src/hooli_data_ingest/resources/__init__.py
+++ b/hooli-data-ingest/src/hooli_data_ingest/resources/__init__.py
@@ -82,7 +82,7 @@ if get_env() != "LOCAL":
                 type="snowflake",
                 host=EnvVar("SNOWFLAKE_HOST"),
                 user=EnvVar("SNOWFLAKE_USER"),
-                password=EnvVar("SNOWFLAKE_PASSWORD"),
+                private_key=EnvVar("SNOWFLAKE_KEY"),
                 role=EnvVar("SNOWFLAKE_ROLE"),
                 database="DEMO_DB2" if get_env() == "PROD" else "DEMO_DB2_BRANCH",
                 schema="RAW_DATA",

--- a/hooli-snowflake-insights/src/hooli_snowflake_insights/definitions.py
+++ b/hooli-snowflake-insights/src/hooli_snowflake_insights/definitions.py
@@ -33,14 +33,14 @@ resource_def = {
         "snowflake_insights": SnowflakeResource(
             account=EnvVar("SNOWFLAKE_ACCOUNT"),
             user=EnvVar("SNOWFLAKE_USER"),
-            password=EnvVar("SNOWFLAKE_PASSWORD"),
+            private_key=EnvVar("SNOWFLAKE_KEY"),
         ),
     },
     "PROD": {
         "snowflake_insights": SnowflakeResource(
             account=EnvVar("SNOWFLAKE_ACCOUNT"),
             user=EnvVar("SNOWFLAKE_USER"),
-            password=EnvVar("SNOWFLAKE_PASSWORD"),
+            private_key=EnvVar("SNOWFLAKE_KEY"),
         ),
     },
 }


### PR DESCRIPTION
this is now the recommended way for snowflake to connect. Tested locally by pretending I was on a branch deployment on:

* the IO manager
* dbt
* sling

Will test on branch deploy as well