### PR TITLE
Migrate dbt manifest management to dg plus integrations dbt manage-manifest

### DIFF
--- a/.github/workflows/deploy-dagster-cloud.yml
+++ b/.github/workflows/deploy-dagster-cloud.yml
@@ -266,7 +266,7 @@ jobs:
       #Deploy
       - name: Deploy to Dagster Cloud
         id: ci-deploy
-        if: steps.prerun.outputs.result != 'skip'
+        if: steps.prerun.outputs.result != 'skip' && env.LOCATIONS != ''
         uses: dagster-io/dagster-cloud-action/actions/utils/dagster-cloud-cli@v1.12.14
         with:
          command: "ci deploy $LOCATIONS"
@@ -283,7 +283,7 @@ jobs:
 
       # Trigger dbt slim CI job
       - name: Trigger dbt slim CI
-        if: steps.prerun.outputs.result != 'skip' && github.event_name == 'pull_request' && steps.changed-files.outputs.hooli-bi_any_changed == 'true'
+        if: steps.prerun.outputs.result != 'skip' && github.event_name == 'pull_request' && steps.changed-files.outputs.hooli-data-eng_any_changed == 'true'
         uses: dagster-io/dagster-cloud-action/actions/utils/run@v1.12.14
         with:
           location_name: data-eng-pipeline

--- a/.github/workflows/deploy-dagster-cloud.yml
+++ b/.github/workflows/deploy-dagster-cloud.yml
@@ -119,7 +119,7 @@ jobs:
         run: |
           uv venv
           source .venv/bin/activate
-          uv pip install dagster-dbt dagster-cloud dbt-core dbt-duckdb "dbt-snowflake<=1.8.4" --upgrade;
+          uv pip install dagster-dbt dagster-cloud dagster-dg-cli dbt-core dbt-duckdb "dbt-snowflake<=1.8.4" --upgrade;
 
       - name: Validate configuration
         id: ci-validate
@@ -169,7 +169,7 @@ jobs:
         run: |
           source .venv/bin/activate
           dagster-dbt project prepare-and-package --file hooli-data-eng/src/hooli_data_eng/defs/dbt/resources.py
-          dagster-cloud ci dagster-dbt project manage-state --file hooli-data-eng/src/hooli_data_eng/defs/dbt/resources.py --source-deployment data-eng-prod 
+          dg plus integrations dbt manage-manifest --file hooli-data-eng/src/hooli_data_eng/defs/dbt/resources.py --source-deployment data-eng-prod
 
       - name: Build and upload Docker image for data-eng-pipeline
         if: steps.prerun.outputs.result != 'skip' && steps.changed-files.outputs.hooli-data-eng_any_changed == 'true'

--- a/dbt_project/models/CLEANED/orders_aggregated.sql
+++ b/dbt_project/models/CLEANED/orders_aggregated.sql
@@ -1,1 +1,2 @@
-select * from {{ ref("orders_cleaned") }}
+select * 
+from {{ ref("orders_cleaned") }}

--- a/hooli-data-eng/src/hooli_data_eng/defs/dbt/component.py
+++ b/hooli-data-eng/src/hooli_data_eng/defs/dbt/component.py
@@ -153,11 +153,11 @@ def _process_partitioned_dbt_assets(
         context.log.info(f"Compiled SQL for {model_name}:\n{result['compiled_code']}")
 
 
-def get_hooli_translator():
+def get_hooli_translator(enable_code_references: bool = True):
     return CustomDagsterDbtTranslator(
         settings=DagsterDbtTranslatorSettings(
             enable_asset_checks=True,
-            enable_code_references=True,
+            enable_code_references=enable_code_references,
         )
     )
 
@@ -320,7 +320,7 @@ def get_slim_ci_job():
             dbt.cli(
                 args=dbt_command,
                 manifest=dbt_project.manifest_path,
-                dagster_dbt_translator=get_hooli_translator(),
+                dagster_dbt_translator=get_hooli_translator(enable_code_references=False),
             )
             .stream()
             .fetch_row_counts()


### PR DESCRIPTION
Replaces `dagster-cloud ci dagster-dbt project manage-state` with `dg plus integrations dbt manage-manifest` in CI, which uploads/downloads the dbt manifest at organization scope instead of deployment scope. This is required for `dg plus integrations dbt download-manifest` to work for local development (e.g. `dbt build --select "my_model+" --defer --state dbt_project/target/defer/`).                               

Also adds `dagster-dg-cli` to the CI pip install step.

Lastly, reverts slim ci step to trigger on changes to `hooli-data-eng` instead of `hooli-bi`