### PR TITLE
Use Snowflake key pair auth on gtm20

### DIFF
--- a/.github/workflows/deploy-dagster-cloud.yml
+++ b/.github/workflows/deploy-dagster-cloud.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Pre-run checks
         id: prerun
-        uses: dagster-io/dagster-cloud-action/actions/utils/prerun@v0.1.47
+        uses: dagster-io/dagster-cloud-action/actions/utils/prerun@v1.12.14
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -117,14 +117,14 @@ jobs:
       - name: Validate configuration
         id: ci-validate
         if: steps.prerun.outputs.result != 'skip'
-        uses: dagster-io/dagster-cloud-action/actions/utils/dagster-cloud-cli@v0.1.47
+        uses: dagster-io/dagster-cloud-action/actions/utils/dagster-cloud-cli@v1.12.14
         with:
           command: "ci check --project-dir ${{ env.DAGSTER_PROJECT_DIR }} --dagster-cloud-yaml-path ${{ env.DAGSTER_CLOUD_YAML_PATH }}"
 
       - name: Initialize build session
         id: ci-init
         if: steps.prerun.outputs.result != 'skip'
-        uses: dagster-io/dagster-cloud-action/actions/utils/ci-init@v0.1.47
+        uses: dagster-io/dagster-cloud-action/actions/utils/ci-init@v1.12.14
         with:
           project_dir: ${{ env.DAGSTER_PROJECT_DIR }}
           dagster_cloud_yaml_path: ${{ env.DAGSTER_CLOUD_YAML_PATH }}
@@ -237,14 +237,11 @@ jobs:
               eval "$line"
             fi
           done
-        # uses: dagster-io/dagster-cloud-action/actions/utils/dagster-cloud-cli@v0.1.47
-        # with:
-        #   command: "ci set-build-output $LOCATIONS_WITH_IMAGE"
       #Deploy
       - name: Deploy to Dagster Cloud
         id: ci-deploy
         if: steps.prerun.outputs.result != 'skip'
-        uses: dagster-io/dagster-cloud-action/actions/utils/dagster-cloud-cli@v0.1.47
+        uses: dagster-io/dagster-cloud-action/actions/utils/dagster-cloud-cli@v1.12.14
         with:
          command: "ci deploy $LOCATIONS"
 
@@ -252,14 +249,14 @@ jobs:
       - name: Get branch deployment
         id: get-branch-deployment
         if: steps.prerun.outputs.result != 'skip' && github.event_name == 'pull_request'
-        uses: dagster-io/dagster-cloud-action/actions/utils/get_branch_deployment@v0.1
+        uses: dagster-io/dagster-cloud-action/actions/utils/get_branch_deployment@v1.12.14
         with:
           organization_id: 'hooli'
 
       # Trigger dbt slim CI job
       - name: Trigger dbt slim CI
         if: steps.prerun.outputs.result != 'skip' && github.event_name == 'pull_request' && steps.changed-files.outputs.hooli-bi_any_changed == 'true'
-        uses: dagster-io/dagster-cloud-action/actions/utils/run@v0.1
+        uses: dagster-io/dagster-cloud-action/actions/utils/run@v1.12.14
         with:
           location_name: data-eng-pipeline
           deployment: ${{ steps.get-branch-deployment.outputs.deployment }}
@@ -270,13 +267,13 @@ jobs:
       - name: Update PR comment for branch deployments
         id: ci-notify
         if: steps.prerun.outputs.result != 'skip' && always()
-        uses: dagster-io/dagster-cloud-action/actions/utils/dagster-cloud-cli@v0.1.47
+        uses: dagster-io/dagster-cloud-action/actions/utils/dagster-cloud-cli@v1.12.14
         with:
           command: "ci notify --project-dir=${{ env.DAGSTER_PROJECT_DIR }}"
 
       - name: Generate summary
         id: ci-summary
         if: steps.prerun.outputs.result != 'skip' && always()
-        uses: dagster-io/dagster-cloud-action/actions/utils/dagster-cloud-cli@v0.1.47
+        uses: dagster-io/dagster-cloud-action/actions/utils/dagster-cloud-cli@v1.12.14
         with:
           command: "ci status --output-format=markdown >> $GITHUB_STEP_SUMMARY"

--- a/dbt_project/profiles.yml
+++ b/dbt_project/profiles.yml
@@ -10,9 +10,9 @@ dbt_project:
       type: snowflake
       account: "{{ env_var('SNOWFLAKE_ACCOUNT', '') }}"
 
-      # User/password auth
+      # User/private_key auth
       user: "{{ env_var('SNOWFLAKE_USER', '') }}"
-      password: "{{ env_var('SNOWFLAKE_PASSWORD', '') }}"
+      private_key: "{{ env_var('SNOWFLAKE_KEY', '') }}"
 
       database: DEMO_DB2
       warehouse: TINY_WAREHOUSE
@@ -23,9 +23,9 @@ dbt_project:
       type: snowflake
       account: "{{ env_var('SNOWFLAKE_ACCOUNT', '') }}"
 
-      # User/password auth
+      # User/private_key auth
       user: "{{ env_var('SNOWFLAKE_USER', '') }}"
-      password: "{{ env_var('SNOWFLAKE_PASSWORD', '') }}"
+      private_key: "{{ env_var('SNOWFLAKE_KEY', '') }}"
 
       database: DEMO_DB2_BRANCH
       warehouse: TINY_WAREHOUSE

--- a/hooli-data-eng/hooli_data_eng/defs/data_ingest/resources.py
+++ b/hooli-data-eng/hooli_data_eng/defs/data_ingest/resources.py
@@ -82,7 +82,7 @@ if get_env() != "LOCAL":
                 type="snowflake",
                 host=EnvVar("SNOWFLAKE_HOST"),
                 user=EnvVar("SNOWFLAKE_USER"),
-                password=EnvVar("SNOWFLAKE_PASSWORD"),
+                private_key=EnvVar("SNOWFLAKE_KEY"),
                 role=EnvVar("SNOWFLAKE_ROLE"),
                 database="DEMO_DB2" if get_env() == "PROD" else "DEMO_DB2_BRANCH",
                 schema="RAW_DATA",

--- a/hooli-data-eng/hooli_data_eng/defs/databricks/resources.py
+++ b/hooli-data-eng/hooli_data_eng/defs/databricks/resources.py
@@ -84,8 +84,8 @@ db_step_launcher = databricks_pyspark_step_launcher.configured(
                 "scope": "dagster-test",
             },
             {
-                "name": "SNOWFLAKE_PASSWORD",
-                "key": "snowflake_password",
+                "name": "SNOWFLAKE_KEY",
+                "key": "snowflake_key",
                 "scope": "dagster-test",
             },
             {

--- a/hooli-data-eng/hooli_data_eng/defs/snowflake_insights/definitions.py
+++ b/hooli-data-eng/hooli_data_eng/defs/snowflake_insights/definitions.py
@@ -33,14 +33,14 @@ resource_def = {
         "snowflake_insights": SnowflakeResource(
             account=EnvVar("SNOWFLAKE_ACCOUNT"),
             user=EnvVar("SNOWFLAKE_USER"),
-            password=EnvVar("SNOWFLAKE_PASSWORD"),
+            private_key=EnvVar("SNOWFLAKE_KEY"),
         ),
     },
     "PROD": {
         "snowflake_insights": SnowflakeResource(
             account=EnvVar("SNOWFLAKE_ACCOUNT"),
             user=EnvVar("SNOWFLAKE_USER"),
-            password=EnvVar("SNOWFLAKE_PASSWORD"),
+            private_key=EnvVar("SNOWFLAKE_KEY"),
         ),
     },
 }

--- a/hooli-data-eng/hooli_data_eng/resources.py
+++ b/hooli-data-eng/hooli_data_eng/resources.py
@@ -19,7 +19,7 @@ snowflake_branch_io_manager = SnowflakePandasIOManager(
     database="DEMO_DB2_BRANCH",
     account=dg.EnvVar("SNOWFLAKE_ACCOUNT"),
     user=dg.EnvVar("SNOWFLAKE_USER"),
-    password=dg.EnvVar("SNOWFLAKE_PASSWORD"),
+    private_key=dg.EnvVar("SNOWFLAKE_KEY"),
     warehouse="TINY_WAREHOUSE",
 )
 
@@ -27,6 +27,6 @@ snowflake_prod_io_manager = SnowflakePandasIOManager(
     database="DEMO_DB2",
     account=dg.EnvVar("SNOWFLAKE_ACCOUNT"),
     user=dg.EnvVar("SNOWFLAKE_USER"),
-    password=dg.EnvVar("SNOWFLAKE_PASSWORD"),
+    private_key=dg.EnvVar("SNOWFLAKE_KEY"),
     warehouse="TINY_WAREHOUSE",
 )

--- a/hooli-etl-pipeline/transform/jdbt/profiles.yml
+++ b/hooli-etl-pipeline/transform/jdbt/profiles.yml
@@ -10,7 +10,7 @@ jdbt:
     PROD:
       type: snowflake
       account: "{{ env_var('SNOWFLAKE_ACCOUNT', '') }}"
-      # User/password auth
+      # User/private_key auth
       user: "{{ env_var('SNOWFLAKE_USER', '') }}"
       private_key: "{{ env_var('SNOWFLAKE_KEY', '') }}"
       database: DEMO_DB2
@@ -21,7 +21,7 @@ jdbt:
     BRANCH:
       type: snowflake
       account: "{{ env_var('SNOWFLAKE_ACCOUNT', '') }}"
-      # User/password auth
+      # User/private_key auth
       user: "{{ env_var('SNOWFLAKE_USER', '') }}"
       private_key: "{{ env_var('SNOWFLAKE_KEY', '') }}"
       database: DEMO_DB2_BRANCH


### PR DESCRIPTION
## Summary
- Replace Snowflake password auth with SNOWFLAKE_KEY/private_key in gtm20 dbt and Dagster resources
- Update Databricks-launched jobs to receive SNOWFLAKE_KEY instead of SNOWFLAKE_PASSWORD
- Fix stale private-key auth comments in the gtm20 ETL dbt profile

## Verification
- Searched repo for SNOWFLAKE_PASSWORD/password auth; only GitHub Actions mask-password remains
- Ran: python3 -m compileall -q changed Python resources
- Parsed changed dbt profiles with PyYAML