### PR TITLE
[Designer] Add ScheduledJobComponent[2]

### DIFF
--- a/hooli_data_eng/hooli_data_eng/defs/scheduledjobcomponent_2/defs.yaml
+++ b/hooli_data_eng/hooli_data_eng/defs/scheduledjobcomponent_2/defs.yaml
@@ -1,0 +1,5 @@
+type: hooli_data_eng.hooli_data_eng.components.ScheduledJobComponent
+attributes:
+  cron_schedule: 0 3 1 * *
+  asset_selection: ANALYTICS/company_perf, ANALYTICS/company_stats, ANALYTICS/order_stats
+  job_name: eric_job


### PR DESCRIPTION
## Component added via Dagster Designer

- **Type:** `hooli_data_eng.hooli_data_eng.components.ScheduledJobComponent`
- **Instance id:** `ScheduledJobComponent[2]`
- **Target location:** `data-eng-pipeline` (deployment `cf626f6c8ede2fdd7e898e03286787e88ccf2ba4`)
- **Files:** `hooli_data_eng/hooli_data_eng/defs/scheduledjobcomponent_2/defs.yaml`

### defs.yaml

```yaml
type: hooli_data_eng.hooli_data_eng.components.ScheduledJobComponent
attributes:
  cron_schedule: 0 3 1 * *
  asset_selection: ANALYTICS/company_perf, ANALYTICS/company_stats, ANALYTICS/order_stats
  job_name: eric_job

```

---
_Draft authored in [Dagster Designer](https://github.com/dagster-io/dagster) — reviewed and shipped through your normal PR workflow._
